### PR TITLE
Channel-oriented memory management

### DIFF
--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -461,6 +461,10 @@ void
 AMQP_CALL amqp_maybe_release_buffers(amqp_connection_state_t state);
 
 AMQP_PUBLIC_FUNCTION
+void
+AMQP_CALL amqp_maybe_release_buffers_on_channel(amqp_connection_state_t state, amqp_channel_t channel);
+
+AMQP_PUBLIC_FUNCTION
 int
 AMQP_CALL amqp_send_frame(amqp_connection_state_t state, amqp_frame_t const *frame);
 

--- a/librabbitmq/amqp_mem.c
+++ b/librabbitmq/amqp_mem.c
@@ -202,3 +202,46 @@ void amqp_bytes_free(amqp_bytes_t bytes)
 {
   free(bytes.bytes);
 }
+
+amqp_pool_t *amqp_get_or_create_channel_pool(amqp_connection_state_t state, amqp_channel_t channel)
+{
+  amqp_pool_table_entry_t *entry;
+  size_t index = channel % POOL_TABLE_SIZE;
+
+  entry = state->pool_table[index];
+
+  for ( ; NULL != entry; entry = entry->next) {
+    if (channel == entry->channel) {
+      return &entry->pool;
+    }
+  }
+
+  entry = malloc(sizeof(amqp_pool_table_entry_t));
+  if (NULL == entry) {
+    return NULL;
+  }
+
+  entry->channel = channel;
+  entry->next = state->pool_table[index];
+  state->pool_table[index] = entry;
+
+  init_amqp_pool(&entry->pool, state->frame_max);
+
+  return &entry->pool;
+}
+
+amqp_pool_t *amqp_get_channel_pool(amqp_connection_state_t state, amqp_channel_t channel)
+{
+  amqp_pool_table_entry_t *entry;
+  size_t index = channel % POOL_TABLE_SIZE;
+
+  entry = state->pool_table[index];
+
+  for ( ; NULL != entry; entry = entry->next) {
+    if (channel == entry->channel) {
+      return &entry->pool;
+    }
+  }
+
+  return NULL;
+}


### PR DESCRIPTION
Rework internal memory management routines so that memory can be managed (free(0'd) on a per-channel instead of a per-connection basis.
