### PR TITLE
Fix: add stdint.h to install target on MSVC < 1600

### DIFF
--- a/librabbitmq/CMakeLists.txt
+++ b/librabbitmq/CMakeLists.txt
@@ -49,7 +49,10 @@ else(WIN32)
 endif(WIN32)
 
 if(MSVC)
-  set(MSINTTYPES_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/../msinttypes")
+  if(MSVC_VERSION LESS 1600)
+    set(MSINTTYPES_INCLUDE "${CMAKE_CURRENT_SOURCE_DIR}/../msinttypes")
+    set(STDINT_H_INSTALL_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../msinttypes/stdint.h")
+  endif(MSVC_VERSION LESS 1600)
 endif(MSVC)
 
 include_directories(${SOCKET_IMPL} ${MSINTTYPES_INCLUDE})
@@ -76,7 +79,7 @@ install(TARGETS rabbitmq
 	ARCHIVE DESTINATION lib
 	PUBLIC_HEADER DESTINATION include)
 
-install(FILES amqp.h ${CMAKE_CURRENT_BINARY_DIR}/amqp_framing.h
+install(FILES amqp.h ${CMAKE_CURRENT_BINARY_DIR}/amqp_framing.h ${STDINT_H_INSTALL_FILE}
 	DESTINATION include)
 
 


### PR DESCRIPTION
MSVC doesn't have stdint.h for versions less than 1600, we need to
both have this included and installed along with the header files
as the stdint.h is used from amqp.h
