### PR TITLE
Fix size t in amqp h

### DIFF
--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -40,6 +40,7 @@
  */
 
 #include <stdint.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
When compiling applications that use amqp.h on linux, they complain about size_t not being defined.

Adding

```
#include <stddef.h>
```

In amqp.h fixes this.

Tested on:
RHEL6/Linux
MSVC-10
MSVC-9
MacOSX-10.7
