### PR TITLE
Build static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,12 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_SOURCE_DIR}/cmake)
 
 find_package(POPT)
 
+option(BUILD_SHARED_LIBS "Build rabbitmq-c as a shared library" ON)
+
+if (WIN32 AND NOT BUILD_SHARED_LIBS)
+  message(FATAL_ERROR "The rabbitmq-c library cannot be built as a static library on Win32. Set BUILD_SHARED_LIBS=ON to get around this.")
+endif()
+
 add_subdirectory(librabbitmq)
 add_subdirectory(examples)
 

--- a/librabbitmq/CMakeLists.txt
+++ b/librabbitmq/CMakeLists.txt
@@ -79,7 +79,7 @@ set(RABBITMQ_SOURCES
     ${SOCKET_IMPL}/socket.h ${SOCKET_IMPL}/socket.c
 )
 
-add_library(rabbitmq SHARED ${RABBITMQ_SOURCES})
+add_library(rabbitmq ${RABBITMQ_SOURCES})
 
 if(WIN32)
   target_link_libraries(rabbitmq ws2_32)


### PR DESCRIPTION
Adding option to the CMake build to build rabbitmq-c
library as a static library.

It is disabled on the WIN32 platform as the amqp.h
header has __declspec(dllimport) statements that need
to be different when using a static library.

This addresses #18
