### PR TITLE
Add RPM .spec file

### DIFF
--- a/librabbitmq.spec
+++ b/librabbitmq.spec
@@ -43,7 +43,7 @@ built using librabbitmq.
 %setup -q
 
 %build
-%configure
+%configure --enable-static
 %{__make} %{?_smp_mflags}
 
 %install
@@ -60,7 +60,7 @@ built using librabbitmq.
 
 %files devel
 %defattr(-,root,root)
-#%{_libdir}/librabbitmq.a
+%{_libdir}/librabbitmq.a
 %{_libdir}/librabbitmq.la
 %{_libdir}/librabbitmq.so
 %{_libdir}/pkgconfig/librabbitmq.pc


### PR DESCRIPTION
I created this a while ago when the code was still hosted in Mercurial and so I've fixed it up. Only thing I noticed was that the librabbitmq.a lib has since stopped being installed, perhaps that's intentional though?

Tested on CentOS 5/6 for both i386 & x86_64.
