### PR TITLE
Correct #ifdef DISABLE_SIGPIPE_WITH_SETSOCKOPT

### DIFF
--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -82,7 +82,7 @@ int amqp_open_socket(char const *hostname,
       last_error = -amqp_socket_error();
       continue;
     }
-#if DISABLE_SIGPIPE_WITH_SETSOCKOPT
+#ifdef DISABLE_SIGPIPE_WITH_SETSOCKOPT
     if (0 != amqp_socket_setsockopt(sockfd, SOL_SOCKET, SO_NOSIGPIPE, &one, sizeof(one)))
     {
       last_error = -amqp_socket_error();


### PR DESCRIPTION
An #ifdef got turned into an #if when the IPv6 changes
were being made, this corrects that.

This corrects #29
