### PR TITLE
Fix for issue #38: Use FormatMessageA instead of FormatMessage

### DIFF
--- a/librabbitmq/win32/socket.c
+++ b/librabbitmq/win32/socket.c
@@ -63,7 +63,7 @@ char *amqp_os_error_string(int err)
 {
 	char *msg, *copy;
 
-	if (!FormatMessage(FORMAT_MESSAGE_FROM_SYSTEM
+	if (!FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM
 			       | FORMAT_MESSAGE_ALLOCATE_BUFFER,
 			   NULL, err,
 			   MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),


### PR DESCRIPTION
FormatMessage might be #defined to be FormatMessageW in case
UNICODE is #defined, expliciting calling the ascii version
of the function corrects this in all cases

CC: issue #38
