### PR TITLE
Debian package fixes for issue #32

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+librabbitmq0 (0.2.0-1ubuntu1) precise; urgency=low
+
+  * Patched to build with cmake
+  * renamed package to librabbitmq0 to match upstream Debian/Ubuntu naming
+
+ -- David Gillies <dgillies@brandscreen.com>  Tue, 18 Sep 2012 17:39:30 +1000
+
 librabbitmq (1.0-1) unstable; urgency=low
 
   * Initial release

--- a/debian/control
+++ b/debian/control
@@ -2,12 +2,12 @@ Source: librabbitmq
 Section: libs
 Priority: extra
 Maintainer: Tony Garnock-Jones <tonygarnockjones@gmail.com>
-Build-Depends: debhelper (>= 7), autoconf, automake, libtool, python (>= 2.5), python-simplejson, libpopt-dev, xmlto
+Build-Depends: debhelper (>= 7), autoconf, automake, cmake, libtool, python (>= 2.5), python-simplejson, libpopt-dev, xmlto
 Standards-Version: 3.8.1
 Homepage: http://www.rabbitmq.com/
-Vcs-Browser: http://hg.rabbitmq.com/rabbitmq-c
+Vcs-Browser: https://github.com/alanxz/rabbitmq-c
 
-Package: librabbitmq
+Package: librabbitmq0
 Architecture: any
 Section: libs
 Priority: extra

--- a/debian/librabbitmq-dev.install
+++ b/debian/librabbitmq-dev.install
@@ -1,4 +1,2 @@
 debian/tmp/usr/include/*.h	usr/include
-debian/tmp/usr/lib/*.a		usr/lib
-debian/tmp/usr/lib/*.la		usr/lib
-debian/tmp/usr/lib/*.so		usr/lib
+debian/tmp/usr/lib/pkgconfig/*.pc usr/lib/pkgconfig

--- a/debian/librabbitmq.install
+++ b/debian/librabbitmq.install
@@ -1,1 +1,1 @@
-debian/tmp/usr/lib/*.so.*	usr/lib
+debian/tmp/usr/lib/*.so*	usr/lib


### PR DESCRIPTION
- Updated package version to 0.2.0
- Changed package name to librabbitmq0 to match upstream Debian/Ubuntu
  naming
