### PR TITLE
Correct sys/types.h sys/socket.h include order on *BSD

### DIFF
--- a/librabbitmq/unix/socket.c
+++ b/librabbitmq/unix/socket.c
@@ -40,9 +40,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <string.h>
-#include <sys/socket.h>
-#include <sys/types.h>
-#include <unistd.h>
 
 int
 amqp_socket_init(void)

--- a/librabbitmq/unix/socket.h
+++ b/librabbitmq/unix/socket.h
@@ -34,11 +34,11 @@
  */
 
 #include <errno.h>
-#include <netdb.h>
+#include <sys/types.h>      /* On older BSD this must come before net includes */
 #include <netinet/in.h>
 #include <netinet/tcp.h>
 #include <sys/socket.h>
-#include <sys/types.h>
+#include <netdb.h>
 #include <sys/uio.h>
 #include <unistd.h>
 


### PR DESCRIPTION
The include order of <sys/types.h> <sys/socket.h> matters on certain older *BSD variants. This is a potential fix for that.

This is a potential correction for issue #40
