### PR TITLE
automake: Enable make dist when docs were disabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -263,12 +263,12 @@ XMLTO_FLAGS = \
 
 %.7: %.xml $(top_builddir)/tools/doc/man-date.ent
 	$(AM_V_GEN)$(XMLTO) $(XMLTO_FLAGS) -o $(top_builddir)/tools/doc man $<
+endif # DOCS
+endif # TOOLS
 
 $(top_builddir)/tools/doc/man-date.ent:
 	$(AM_V_at)$(MKDIR_P) $(top_builddir)/tools/doc
 	$(AM_V_GEN)date +'%Y-%m-%d' > $@
-endif # DOCS
-endif # TOOLS
 
 EXTRA_DIST = \
 	$(man_MANS) \


### PR DESCRIPTION
In case docs (or tools) were disabled either explicitly or otherwise,
make dist with automake did not work, due to tools/doc/man-date.ent
not getting generated, while being included in EXTRA_DIST.

Since generating said file does not need anything special, move the
rule out of the DOCS and TOOLS ifs. This results in said file always
getting generated when needed, regardless of docs or tools being
disabled.

Signed-off-by: Gergely Nagy algernon@madhouse-project.org
