### PR TITLE
autotools: Don't include man-date.ent as part of dist package

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -290,8 +290,7 @@ EXTRA_DIST = \
 	tools/doc/amqp-delete-queue.xml \
 	tools/doc/amqp-get.xml \
 	tools/doc/amqp-publish.xml \
-	tools/doc/librabbitmq-tools.xml \
-	$(top_builddir)/tools/doc/man-date.ent
+	tools/doc/librabbitmq-tools.xml
 
 MOSTLYCLEANFILES = \
 	$(top_builddir)/librabbitmq/amqp_framing.c \


### PR DESCRIPTION
man-date.ent is a file generated by Makefile.am which puts the current
date in the man pages as they are generated.

The filename was listed in EXTRA_DIST which caused failures in
make dist when --disable-docs or --disable-tools was passed to the
configure script.

Fix is to remove man-date.ent as it really shouldn't be a part of
the distribution package

This is a fix for the issue that was addressed in #62
