### PR TITLE
Lower python version requirement for autoconf

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -105,7 +105,7 @@ AC_ARG_ENABLE([64-bit],
                AX_TRY_LDFLAGS([-m64], [AX_LDFLAGS([-m64])])],
               [enable_64_bit=no])
 
-AM_PATH_PYTHON([2.5])
+AM_PATH_PYTHON([2.4])
 
 AX_PYTHON_MODULE([json], [])
 AS_IF([test "x$HAVE_PYMOD_JSON" = "xno"],


### PR DESCRIPTION
I've been able to build successfully without any problems using python 2.4. This pull request simply lowers the version requirement.
