### PR TITLE
Outdated link in 'information' field

### DIFF
--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -443,7 +443,7 @@ static int amqp_login_inner(amqp_connection_state_t state,
     properties[1].key = amqp_cstring_bytes("information");
     properties[1].value.kind = AMQP_FIELD_KIND_UTF8;
     properties[1].value.value.bytes
-      = amqp_cstring_bytes("See http://hg.rabbitmq.com/rabbitmq-c/");
+      = amqp_cstring_bytes("See https://github.com/alanxz/rabbitmq-c");
 
     s.client_properties.num_entries = 2;
     s.client_properties.entries = properties;


### PR DESCRIPTION
Hi.
I've been reading RabbitMQ logs today, and I've noticed my program's (which uses rabbitmq-c) client_properties are reported as

```
[{"product","rabbitmq-c"},{"information","See http://hg.rabbitmq.com/rabbitmq-c/"}]
```

...which clearly is outdated link.  I've managed to fix it.
