### PR TITLE
autoconf: remove incorrect --enable-64-bit flag

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -97,14 +97,6 @@ AC_SEARCH_LIBS([socket], [socket], [],
                              [-lnsl])])
 AC_CHECK_FUNCS([htonll])
 
-# 64-bit option
-AC_ARG_ENABLE([64-bit],
-              [AS_HELP_STRING([--enable-64-bit],
-                              [produce 64-bit library @<:@no@:>@])],
-              [AX_TRY_CFLAGS([-m64], AX_CFLAGS([-m64]))
-               AX_TRY_LDFLAGS([-m64], [AX_LDFLAGS([-m64])])],
-              [enable_64_bit=no])
-
 AM_PATH_PYTHON([2.4])
 
 AX_PYTHON_MODULE([json], [])
@@ -157,7 +149,6 @@ AC_MSG_RESULT([
 $PACKAGE_NAME build options:
 	Host: $host
 	Version: $VERSION
-	64-bit: $enable_64_bit
 	Tools: $enable_tools
 	Documentation: $enable_docs
 ])


### PR DESCRIPTION
This is a fix for issue #64: autotools: --enable-64-bit doesn't work
consistently. This flag doesn't work correctly in the presence of other
CFLAGS variables, or if its not specified and being built on a 64-bit
platform the output at the end of the configure script will be incorrect
causing confusion.

The fix is to remove this flag from the configure.ac script and allow
the users to force building a 32-bit or 64-bit library by setting the
CFLAGS/LDFLAGS appropriate for their compiler/platform at ./configure
time.
