### PR TITLE
Add amqp_login function to specify properties to send to broker

### DIFF
--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -471,6 +471,12 @@ AMQP_CALL amqp_login(amqp_connection_state_t state, char const *vhost,
                      int channel_max, int frame_max, int heartbeat,
                      amqp_sasl_method_enum sasl_method, ...);
 
+AMQP_PUBLIC_FUNCTION
+amqp_rpc_reply_t
+AMQP_CALL amqp_login_with_properties(amqp_connection_state_t state, char const *vhost,
+        int channel_max, int frame_max, int heartbeat,
+        const amqp_table_t *properties, amqp_sasl_method_enum sasl_method, ...);
+
 struct amqp_basic_properties_t_;
 
 AMQP_PUBLIC_FUNCTION


### PR DESCRIPTION
Add an overload to the `amqp_login` function that allows the user to send arbitrary properties to the broker.

This will likely be a separate symbol to maintain API/ABI with existing programs (`amqp_login_with_properties`)

The functionality of the new function would be identical to `amqp_login` in every way, except it would have an additional properties parameter that would allow a user to specify additional properties to be sent to the broker.  These properties would be merged with the other properties that rabbitmq-c already sends.  Properties that conflict with existing properties being sent, will silently be over-riden by those being sent by the library.
