### PR TITLE
Fixes #102: SIGPIPE not disabled on Mac OS X/*BSD

### DIFF
--- a/librabbitmq/unix/socket.h
+++ b/librabbitmq/unix/socket.h
@@ -55,12 +55,12 @@ amqp_socket_error(void);
 #define amqp_socket_close close
 #define amqp_socket_writev writev
 
-#ifndef MSG_NOSIGNAL
-# define MSG_NOSIGNAL 0x0
-#endif
-
 #if defined(SO_NOSIGPIPE) && !defined(MSG_NOSIGNAL)
 # define DISABLE_SIGPIPE_WITH_SETSOCKOPT
+#endif
+
+#ifndef MSG_NOSIGNAL
+# define MSG_NOSIGNAL 0x0
 #endif
 
 #endif


### PR DESCRIPTION
The order of preprocessor defines in librabbitmq/unix/socket.h prevents
DISABLE_SIGPIPE_WITH_SETSOCKOPT from ever being defined, and thus
SIGPIPE not being disabled correctly. This fixes that error.

This is a fix for issue #102 
