### PR TITLE
BUG: double-free in ssl-socket on connect failure

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -297,6 +297,7 @@ error_out2:
   self->sockfd = -1;
 error_out1:
   SSL_free(self->ssl);
+  self->ssl = NULL;
   goto exit;
 }
 


### PR DESCRIPTION
In amqp_ssl_socket_open() set self->ssl to NULL after SSL_free() to
avoid calling SSL_free() on a SSL object that has already been freed.

This fixes #129 crash while call amqp_destroy_connection() with ssl
