### PR TITLE
* tools/CMakeLists.txt: Fix missing POPT_INCLUDE_DIRS variable.

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -1,5 +1,5 @@
 # vim:set ts=2 sw=2 sts=2 et:
-include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${LIBRABBITMQ_INCLUDE_DIRS} ${POPT_INCLUDE_DIRS})
+include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${LIBRABBITMQ_INCLUDE_DIRS} ${POPT_INCLUDE_DIR})
 
 if (WIN32)
     set(PLATFORM_DIR win32)


### PR DESCRIPTION
Building master on Mac OS X with port fails on a missing include file <popt.h> in tools/common.h. The file is installed and found by cmake, but the correct path (/opt/local/include) is stored in POPT_INCLUDE_DIR instead of POPT_INCLUDE_DIRS. This patch fixes that.
I suppose this problem can only occur when popt.h is not installed in the target installation folder.
Lieven
