### PR TITLE
.gitignore: ignore editor swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,6 @@ tools/doc/man-date.ent
 
 # Ignore editor swap files
 *~
-*.swp
+*.sw?
 .#*
 \#*#


### PR DESCRIPTION
Some source code editors create swap files in the same directory as the
file being edited. These should be ignored by git.
