### PR TITLE
amqp_framing.h: delivery mode constants

### DIFF
--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -715,6 +715,17 @@ typedef enum amqp_status_enum_
   AMQP_STATUS_SSL_CONNECTION_FAILED =     -0x0203  /**< SSL handshake failed. */
 } amqp_status_enum;
 
+/**
+ * AMQP delivery modes.
+ * Use these values for the #amqp_basic_properties_t::delivery_mode field.
+ *
+ * \since v0.5
+ */
+typedef enum {
+	AMQP_DELIVERY_NONPERSISTENT = 1, /**< Non-persistent message */
+	AMQP_DELIVERY_PERSISTENT = 2 /**< Persistent message */
+} amqp_delivery_mode_enum;
+
 AMQP_END_DECLS
 
 #include <amqp_framing.h>

--- a/librabbitmq/amqp_framing.h
+++ b/librabbitmq/amqp_framing.h
@@ -558,17 +558,6 @@ typedef struct amqp_queue_properties_t_ {
   char dummy; /* Dummy field to avoid empty struct */
 } amqp_queue_properties_t;
 
-/**
- * AMQP delivery modes.
- * Use these values for the #amqp_basic_properties_t::delivery_mode field.
- *
- * \since v0.5
- */
-typedef enum {
-	AMQP_DELIVERY_NONPERSISTENT = 1, /**< Non-persistent message */
-	AMQP_DELIVERY_PERSISTENT = 2 /**< Persistent message */
-} amqp_delivery_mode_enum;
-
 #define AMQP_BASIC_CLASS (0x003C) /* 60 */
 #define AMQP_BASIC_CONTENT_TYPE_FLAG (1 << 15)
 #define AMQP_BASIC_CONTENT_ENCODING_FLAG (1 << 14)


### PR DESCRIPTION
I've added the delivery mode constants directly to amqp_framing.h instead of using the codegen.py facility, for codegen.py changed the amqp_framing.h file rather extensively. Do you actually still use codegen.py? If so, maybe you can sort it out? Thanks.
