### PR TITLE
Fixed the library path for the x86_64 architecture

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,7 +297,7 @@ endif ()
 
 set(prefix ${CMAKE_INSTALL_PREFIX})
 set(exec_prefix "\${prefix}")
-set(libdir "\${exec_prefix}/lib")
+set(libdir "\${exec_prefix}/lib${LIB_SUFFIX}")
 set(includedir "\${prefix}/include")
 set(libs_private ${SOCKET_LIBRARIES} ${LIBRT})
 if (ENABLE_SSL_SUPPORT)
@@ -314,7 +314,7 @@ configure_file(librabbitmq.pc.in ${CMAKE_CURRENT_BINARY_DIR}/librabbitmq.pc @ONL
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/librabbitmq.pc
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig
+  DESTINATION ${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}/pkgconfig
   )
 
 if (BUILD_SHARED_LIBS)

--- a/librabbitmq/CMakeLists.txt
+++ b/librabbitmq/CMakeLists.txt
@@ -144,8 +144,8 @@ if (BUILD_SHARED_LIBS)
 
     install(TARGETS rabbitmq
         RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-        ARCHIVE DESTINATION lib
+        LIBRARY DESTINATION lib${LIB_SUFFIX}
+        ARCHIVE DESTINATION lib${LIB_SUFFIX}
         )
     install_pdb(rabbitmq)
 
@@ -165,7 +165,7 @@ if (BUILD_STATIC_LIBS)
     endif (WIN32)
 
     install(TARGETS rabbitmq-static
-        ARCHIVE DESTINATION lib
+        ARCHIVE DESTINATION lib${LIB_SUFFIX}
         )
     install_pdb(rabbitmq-static)
 


### PR DESCRIPTION
Added $ {LIB_SUFFIX}, because always installed in lib. For x86_64 it's not correct
