### PR TITLE
Table field kind fixes

### DIFF
--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -505,21 +505,53 @@ typedef enum {
   AMQP_FIELD_KIND_BOOLEAN = 't',  /**< boolean type. 0 = false, 1 = true @see amqp_boolean_t */
   AMQP_FIELD_KIND_I8 = 'b',       /**< 8-bit signed integer, datatype: int8_t */
   AMQP_FIELD_KIND_U8 = 'B',       /**< 8-bit unsigned integer, datatype: uint8_t */
-  AMQP_FIELD_KIND_I16 = 's',      /**< 16-bit signed integer, datatype: int16_t */
+  AMQP_FIELD_KIND_I16 = 'U',      /**< 16-bit signed integer, datatype: int16_t */
   AMQP_FIELD_KIND_U16 = 'u',      /**< 16-bit unsigned integer, datatype: uint16_t */
   AMQP_FIELD_KIND_I32 = 'I',      /**< 32-bit signed integer, datatype: int32_t */
   AMQP_FIELD_KIND_U32 = 'i',      /**< 32-bit unsigned integer, datatype: uint32_t */
-  AMQP_FIELD_KIND_I64 = 'l',      /**< 64-bit signed integer, datatype: int64_t */
-  AMQP_FIELD_KIND_U64 = 'L',      /**< 64-bit unsigned integer, datatype: uint64_t */
+  AMQP_FIELD_KIND_I64 = 'L',      /**< 64-bit signed integer, datatype: int64_t */
+  AMQP_FIELD_KIND_U64 = 'l',      /**< 64-bit unsigned integer, datatype: uint64_t */
   AMQP_FIELD_KIND_F32 = 'f',      /**< single-precision floating point value, datatype: float */
   AMQP_FIELD_KIND_F64 = 'd',      /**< double-precision floating point value, datatype: double */
   AMQP_FIELD_KIND_DECIMAL = 'D',  /**< amqp-decimal value, datatype: amqp_decimal_t */
-  AMQP_FIELD_KIND_UTF8 = 'S',     /**< UTF-8 null-terminated character string, datatype: amqp_bytes_t */
+
+  /**
+   * Short string.
+   * Data type: #amqp_bytes_t.
+   * The short string must not contain NUL characters.
+   * The length of the short string must not exceed 255 octets.
+   *
+   * \since v0.5
+   */
+  AMQP_FIELD_KIND_SHORTSTRING = 's',
+
+  /**
+   * UTF-8 null-terminated character string, datatype: #amqp_bytes_t
+   *
+   * \deprecated Please use #AMQP_FIELD_KIND_LONGSTRING instead.
+   */
+  AMQP_FIELD_KIND_UTF8 = 'S',
+
+  /**
+   * Long string.
+   * Datatype #amqp_bytes_t.
+   *
+   * \since v0.5
+   */
+  AMQP_FIELD_KIND_LONGSTRING = 'S',
+
   AMQP_FIELD_KIND_ARRAY = 'A',    /**< field array (repeated values of another datatype. datatype: amqp_array_t */
   AMQP_FIELD_KIND_TIMESTAMP = 'T',/**< 64-bit timestamp. datatype uint64_t */
   AMQP_FIELD_KIND_TABLE = 'F',    /**< field table. encapsulates a table inside a table entry. datatype: amqp_table_t */
   AMQP_FIELD_KIND_VOID = 'V',     /**< empty entry */
-  AMQP_FIELD_KIND_BYTES = 'x'     /**< unformatted byte string, datatype: amqp_bytes_t */
+
+  /**
+   * Unformatted byte string.
+   * Datatype: #amqp_bytes_t
+   *
+   * \warning This field value type is an extension and not part of AMQP 0-9-1.
+   */
+  AMQP_FIELD_KIND_BYTES = 'x'
 } amqp_field_value_kind_t;
 
 /**

--- a/librabbitmq/amqp_table.c
+++ b/librabbitmq/amqp_table.c
@@ -244,8 +244,21 @@ static int amqp_decode_field_value(amqp_bytes_t encoded,
     }
     break;
 
-  case AMQP_FIELD_KIND_UTF8:
-    /* AMQP_FIELD_KIND_UTF8 and AMQP_FIELD_KIND_BYTES have the
+  case AMQP_FIELD_KIND_SHORTSTRING: {
+    uint8_t len;
+    if (!amqp_decode_8(encoded, offset, &len)
+        || !amqp_decode_bytes(encoded, offset, &entry->value.bytes, len)) {
+      goto out;
+    }
+    if (memchr(entry->value.bytes.bytes, '\0', len) != NULL) {
+      /* NUL chars not allowed in shortstring */
+      goto out;
+    }
+    break;
+  }
+
+  case AMQP_FIELD_KIND_LONGSTRING:
+    /* AMQP_FIELD_KIND_LONGSTRING and AMQP_FIELD_KIND_BYTES have the
        same implementation, but different interpretations. */
     /* fall through */
   case AMQP_FIELD_KIND_BYTES: {
@@ -403,8 +416,20 @@ static int amqp_encode_field_value(amqp_bytes_t encoded,
     }
     break;
 
-  case AMQP_FIELD_KIND_UTF8:
-    /* AMQP_FIELD_KIND_UTF8 and AMQP_FIELD_KIND_BYTES have the
+  case AMQP_FIELD_KIND_SHORTSTRING:
+    if (entry->value.bytes.len > 0xff) {
+      res = AMQP_STATUS_INVALID_PARAMETER;
+      goto out;
+    }
+    if (!amqp_encode_8(encoded, offset, entry->value.bytes.len)
+        || !amqp_encode_bytes(encoded, offset, entry->value.bytes)) {
+      res = AMQP_STATUS_TABLE_TOO_BIG;
+      goto out;
+    }
+    break;
+
+  case AMQP_FIELD_KIND_LONGSTRING:
+    /* AMQP_FIELD_KIND_LONGSTRING and AMQP_FIELD_KIND_BYTES have the
        same implementation, but different interpretations. */
     /* fall through */
   case AMQP_FIELD_KIND_BYTES:
@@ -520,7 +545,8 @@ amqp_field_value_clone(amqp_field_value_t *original, amqp_field_value_t *clone, 
       clone->value.decimal = original->value.decimal;
       break;
 
-    case AMQP_FIELD_KIND_UTF8:
+    case AMQP_FIELD_KIND_SHORTSTRING:
+    case AMQP_FIELD_KIND_LONGSTRING:
     case AMQP_FIELD_KIND_BYTES:
       if (0 == original->value.bytes.len) {
         clone->value.bytes = amqp_empty_bytes;

--- a/tests/test_tables.c
+++ b/tests/test_tables.c
@@ -121,7 +121,8 @@ static void dump_value(int indent, amqp_field_value_t v, FILE *out)
             v.value.decimal.value);
     break;
 
-  case AMQP_FIELD_KIND_UTF8:
+  case AMQP_FIELD_KIND_SHORTSTRING:
+  case AMQP_FIELD_KIND_LONGSTRING:
     fprintf(out, " %.*s\n", (int)v.value.bytes.len,
             (char *)v.value.bytes.bytes);
     break;
@@ -176,15 +177,15 @@ static void test_dump_value(FILE *out)
   amqp_field_value_t val;
 
   entries[0].key = amqp_cstring_bytes("zebra");
-  entries[0].value.kind = AMQP_FIELD_KIND_UTF8;
+  entries[0].value.kind = AMQP_FIELD_KIND_LONGSTRING;
   entries[0].value.value.bytes = amqp_cstring_bytes("last");
 
   entries[1].key = amqp_cstring_bytes("aardvark");
-  entries[1].value.kind = AMQP_FIELD_KIND_UTF8;
+  entries[1].value.kind = AMQP_FIELD_KIND_LONGSTRING;
   entries[1].value.value.bytes = amqp_cstring_bytes("first");
 
   entries[2].key = amqp_cstring_bytes("middle");
-  entries[2].value.kind = AMQP_FIELD_KIND_UTF8;
+  entries[2].value.kind = AMQP_FIELD_KIND_LONGSTRING;
   entries[2].value.value.bytes = amqp_cstring_bytes("third");
 
   entries[3].key = amqp_cstring_bytes("number");
@@ -201,11 +202,11 @@ static void test_dump_value(FILE *out)
   entries[5].value.value.u64 = 1234123412341234;
 
   entries[6].key = amqp_cstring_bytes("beta");
-  entries[6].value.kind = AMQP_FIELD_KIND_UTF8;
+  entries[6].value.kind = AMQP_FIELD_KIND_LONGSTRING;
   entries[6].value.value.bytes = amqp_cstring_bytes("second");
 
   entries[7].key = amqp_cstring_bytes("wombat");
-  entries[7].value.kind = AMQP_FIELD_KIND_UTF8;
+  entries[7].value.kind = AMQP_FIELD_KIND_LONGSTRING;
   entries[7].value.value.bytes = amqp_cstring_bytes("fourth");
 
   table.num_entries = 8;
@@ -237,9 +238,9 @@ static uint8_t pre_encoded_table[] = {
   0x00, 0x00, 0x0d, 0x41, 0x20, 0x6c, 0x6f, 0x6e,
   0x67, 0x20, 0x73, 0x74, 0x72, 0x69, 0x6e, 0x67,
   0x04, 0x62, 0x79, 0x74, 0x65, 0x62, 0xff, 0x04,
-  0x6c, 0x6f, 0x6e, 0x67, 0x6c, 0x00, 0x00, 0x00,
+  0x6c, 0x6f, 0x6e, 0x67, 0x4c, 0x00, 0x00, 0x00,
   0x00, 0x49, 0x96, 0x02, 0xd2, 0x05, 0x73, 0x68,
-  0x6f, 0x72, 0x74, 0x73, 0x02, 0x8f, 0x04, 0x62,
+  0x6f, 0x72, 0x74, 0x55, 0x02, 0x8f, 0x04, 0x62,
   0x6f, 0x6f, 0x6c, 0x74, 0x01, 0x06, 0x62, 0x69,
   0x6e, 0x61, 0x72, 0x79, 0x78, 0x00, 0x00, 0x00,
   0x0f, 0x61, 0x20, 0x62, 0x69, 0x6e, 0x61, 0x72,
@@ -274,7 +275,7 @@ static void test_table_codec(FILE *out)
   inner_entries[0].value.value.i32 = 54321;
 
   inner_entries[1].key = amqp_cstring_bytes("two");
-  inner_entries[1].value.kind = AMQP_FIELD_KIND_UTF8;
+  inner_entries[1].value.kind = AMQP_FIELD_KIND_LONGSTRING;
   inner_entries[1].value.value.bytes = amqp_cstring_bytes("A long string");
 
   inner_table.num_entries = 2;
@@ -283,14 +284,14 @@ static void test_table_codec(FILE *out)
   inner_values[0].kind = AMQP_FIELD_KIND_I32;
   inner_values[0].value.i32 = 54321;
 
-  inner_values[1].kind = AMQP_FIELD_KIND_UTF8;
+  inner_values[1].kind = AMQP_FIELD_KIND_LONGSTRING;
   inner_values[1].value.bytes = amqp_cstring_bytes("A long string");
 
   inner_array.num_entries = 2;
   inner_array.entries = inner_values;
 
   entries[0].key = amqp_cstring_bytes("longstr");
-  entries[0].value.kind = AMQP_FIELD_KIND_UTF8;
+  entries[0].value.kind = AMQP_FIELD_KIND_LONGSTRING;
   entries[0].value.value.bytes = amqp_cstring_bytes("Here is a long string");
 
   entries[1].key = amqp_cstring_bytes("signedint");

--- a/tests/test_tables.expected
+++ b/tests/test_tables.expected
@@ -17,9 +17,9 @@ F
   byte ->
     b -1
   long ->
-    l 1234567890
+    L 1234567890
   short ->
-    s 655
+    U 655
   bool ->
     t true
   binary ->
@@ -53,9 +53,9 @@ F
   byte ->
     b -1
   long ->
-    l 1234567890
+    L 1234567890
   short ->
-    s 655
+    U 655
   bool ->
     t true
   binary ->


### PR DESCRIPTION
- Bugfix: short-int has kind 'U', not 's'
- Bugfix: kinds 'L' and 'l' were swapped
- Added: short-string kind ('s')
- Deprecated: name UTF8 in favour of LONGSTRING
- Added: nonconformance warning for byte string kind ('x')
- Updated table test accordingly

What's missing is a test case for short strings. I didn't add one as this pre-encoded table thing is a bit scary.
