### PR TITLE
ENABLE_THREAD_SAFETY guarding seems incomplete

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -539,6 +539,7 @@ amqp_ssl_locking_callback(int mode, int n,
 static int
 initialize_openssl(void)
 {
+#ifdef ENABLE_THREAD_SAFETY
 #ifdef _WIN32
   /* No such thing as PTHREAD_INITIALIZE_MUTEX macro on Win32, so we use this */
   if (NULL == openssl_init_mutex) {
@@ -554,7 +555,6 @@ initialize_openssl(void)
   }
 #endif /* _WIN32 */
 
-#ifdef ENABLE_THREAD_SAFETY
   if (pthread_mutex_lock(&openssl_init_mutex)) {
     return -1;
   }


### PR DESCRIPTION
Seems to me as if the guarding by `ENABLE_THREAD_SAFETY` is meant for the initialization code as well.
See e.g. the `openssl_init_mutex` variable which is not even getting defined unless ENABLE_THREAD_SAFETY is defined.
