### PR TITLE
Use CMAKE_INSTALL_* variables provided by GNUInstallDirs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -306,6 +306,11 @@ if (ENABLE_SSL_SUPPORT)
   endif()
 endif()
 
+set(prefix ${CMAKE_INSTALL_PREFIX})
+set(exec_prefix "\${prefix}")
+set(libdir "\${exec_prefix}/${CMAKE_INSTALL_LIBDIR}")
+set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
+
 configure_file(cmake/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/librabbitmq/config.h)
 configure_file(librabbitmq.pc.in ${CMAKE_CURRENT_BINARY_DIR}/librabbitmq.pc @ONLY)
 

--- a/librabbitmq.pc.in
+++ b/librabbitmq.pc.in
@@ -1,7 +1,7 @@
-prefix=@CMAKE_INSTALL_PREFIX@
-exec_prefix=@CMAKE_INSTALL_PREFIX@
-libdir=@CMAKE_INSTALL_LIBDIR@
-includedir=@CMAKE_INSTALL_INCLUDEDIR@
+prefix=@prefix@
+exec_prefix=@exec_prefix@
+libdir=@libdir@
+includedir=@includedir@
 
 Name: rabbitmq-c
 Description: An AMQP 0-9-1 client library


### PR DESCRIPTION
The paths are hard-coded relative to ${prefix} which results in shared libraries getting installed in usr/lib/ instead of the  multiarch usr/lib/<arch> which poses a problem for the Debian package. This patch adds an include on GNUInstallDirs.cmake and replaces the hard-coded variables with their CMAKE_INSTALL_\* equivalents, enabling a cleaner handling of installation DESTINATIONs.
