### PR TITLE
Fix function amqp_get_monotonic_timestamp return zero

### DIFF
--- a/librabbitmq/amqp_timer.c
+++ b/librabbitmq/amqp_timer.c
@@ -40,7 +40,7 @@
 uint64_t
 amqp_get_monotonic_timestamp(void)
 {
-  static uint64_t NS_PER_COUNT = 0;
+  static double NS_PER_COUNT = 0;
   LARGE_INTEGER perf_count;
 
   if (0 == NS_PER_COUNT) {
@@ -48,14 +48,14 @@ amqp_get_monotonic_timestamp(void)
     if (!QueryPerformanceFrequency(&perf_frequency)) {
       return 0;
     }
-    NS_PER_COUNT = AMQP_NS_PER_S / perf_frequency.QuadPart;
+    NS_PER_COUNT = (double)AMQP_NS_PER_S / perf_frequency.QuadPart;
   }
 
   if (!QueryPerformanceCounter(&perf_count)) {
     return 0;
   }
 
-  return perf_count.QuadPart * NS_PER_COUNT;
+  return (uint64_t)(perf_count.QuadPart * NS_PER_COUNT);
 }
 #endif /* AMQP_WIN_TIMER_API */
 


### PR DESCRIPTION
On one of my PC (Intel Core2 Duo Processor E7500 2.93 GHz),
QueryPerformanceFrequency return 2933330000.
This value is greater than AMQP_NS_PER_S (1000000000).
So, I change uint64_t to double.
