### PR TITLE
Honor delivery mode value from command line

### DIFF
--- a/tools/publish.c
+++ b/tools/publish.c
@@ -120,7 +120,7 @@ int main(int argc, const char **argv)
 
   memset(&props, 0, sizeof props);
   props._flags = AMQP_BASIC_DELIVERY_MODE_FLAG;
-  props.delivery_mode = 2; /* persistent delivery mode */
+  props.delivery_mode = delivery;
 
   if (content_type) {
     props._flags |= AMQP_BASIC_CONTENT_TYPE_FLAG;


### PR DESCRIPTION
This change fixes a bug where delivery mode value was hardcoded to
"persistent" even when --persistent flag wasn't specified on the command
line options.
