### PR TITLE
function amqp_close_socket should be public

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -17,6 +17,7 @@ librabbitmq_librabbitmq_la_LDFLAGS = \
 include_HEADERS = \
 	librabbitmq/amqp.h \
 	librabbitmq/amqp_framing.h \
+	librabbitmq/amqp_socket.h \
 	librabbitmq/amqp_tcp_socket.h
 
 if SSL

--- a/librabbitmq/CMakeLists.txt
+++ b/librabbitmq/CMakeLists.txt
@@ -177,6 +177,7 @@ endif (BUILD_STATIC_LIBS)
 install(FILES
   amqp.h
   ${AMQP_FRAMING_H_PATH}
+  amqp_socket.h
   amqp_tcp_socket.h
   ${AMQP_SSL_SOCKET_H_PATH}
   ${STDINT_H_INSTALL_FILE}

--- a/librabbitmq/amqp_socket.h
+++ b/librabbitmq/amqp_socket.h
@@ -151,7 +151,9 @@ amqp_socket_recv(amqp_socket_t *self, void *buf, size_t len, int flags);
  *
  * \return Zero upon success, non-zero otherwise.
  */
+AMQP_PUBLIC_FUNCTION
 int
+AMQP_CALL
 amqp_socket_close(amqp_socket_t *self);
 
 /**


### PR DESCRIPTION
We should be able to close sockets when we are done using them.
## Signed-off-by: Luka Perkov luka.perkov@sartura.hr

The function is mentioned in librabbitmq/amqp_tcp_socket.h but without this
change it can not be used.
