### PR TITLE
amqp_tcp_socket: update documentation

### DIFF
--- a/librabbitmq/amqp_tcp_socket.h
+++ b/librabbitmq/amqp_tcp_socket.h
@@ -36,7 +36,7 @@ AMQP_BEGIN_DECLS
 /**
  * Create a new TCP socket.
  *
- * Call amqp_socket_close() to release socket resources.
+ * Call amqp_connection_close() to release socket resources.
  *
  * \return A new socket object or NULL if an error occurred.
  *


### PR DESCRIPTION
The socket is closed when amqp_connection_close() is called.

Signed-off-by: Luka Perkov luka.perkov@sartura.hr
