### PR TITLE
Add missing amqp_get_server_properties() function.

### DIFF
--- a/librabbitmq/amqp_connection.c
+++ b/librabbitmq/amqp_connection.c
@@ -519,3 +519,8 @@ int amqp_send_frame(amqp_connection_state_t state,
 
   return res;
 }
+amqp_table_t *
+amqp_get_server_properties(amqp_connection_state_t state)
+{
+  return &state->server_properties;
+}


### PR DESCRIPTION
For whatever reason the code behind `amqp_get_server_properties()` function declaration didn't make it to the repository. This fixes that.

Fixes #170
