### PR TITLE
Use poll(2) for timeouts on socket

### DIFF
--- a/librabbitmq/amqp_timer.h
+++ b/librabbitmq/amqp_timer.h
@@ -37,7 +37,10 @@
 # include <sys/time.h>
 #endif
 
-#define AMQP_NS_PER_S 1000000000
+#define AMQP_MS_PER_S  1000
+#define AMQP_US_PER_MS 1000
+#define AMQP_NS_PER_S  1000000000
+#define AMQP_NS_PER_MS 1000000
 #define AMQP_NS_PER_US 1000
 
 #define AMQP_INIT_TIMER(structure) { \


### PR DESCRIPTION
Use poll(2) instead of select(2) to do timeout operations on sockets. This helps
with the situation where the fd is larger than FD_MAXSIZE.

Fixes #168
