### PR TITLE
MinGW : missing ssize_t typedef

### DIFF
--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -48,6 +48,30 @@
 #define AMQP_END_DECLS
 #endif
 
+/*
+ Probably not the right place to put this but...
+ 
+ After issuing 
+	cmake -G "MinGW Makefiles"   ..
+	cmake --build .
+ the linker complains about a missing getaddrinfo function.
+
+ This is due to the windef.h shipped with MinGW :
+
+		#ifndef WINVER
+		#define WINVER 0x0500
+
+		If you need Win32 API features newer the Win95 and WinNT then you must
+		define WINVER before including windows.h or any other method of including
+		the windef.h header.
+
+
+		#endif
+		
+ So I need a way to force WINVER to 0x0501, see http://support.microsoft.com/kb/955045
+
+*/
+
 #if defined(_WIN32) && defined(__MINGW32__)
 #ifndef WINVER
 #define WINVER 0x0501
@@ -159,6 +183,8 @@ typedef __int64 ssize_t;
 typedef _W64 int ssize_t;
 #endif
 #endif
+
+// include for defining missing ssize_t when compiling under MINGW
 
 #if defined(_WIN32) && defined(__MINGW32__)
 #include <sys/types.h>


### PR DESCRIPTION
Fixed compilation errors for MinGW makefiles generator.
- Missing ssize_t definition
- Missing WINVER ( for winsock functions)

tested with mingw/gcc 4.8.1
