### PR TITLE
Honor the self->verify argument for peers and hosts

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -264,13 +264,14 @@ amqp_ssl_socket_open(void *base, const char *host, int port, struct timeval *tim
     goto error_out2;
   }
 
-  result = SSL_get_verify_result(self->ssl);
-  if (X509_V_OK != result) {
-    self->internal_error = result;
-    status = AMQP_STATUS_SSL_PEER_VERIFY_FAILED;
-    goto error_out3;
-  }
   if (self->verify) {
+    result = SSL_get_verify_result(self->ssl);
+    if (X509_V_OK != result) {
+      self->internal_error = result;
+      status = AMQP_STATUS_SSL_PEER_VERIFY_FAILED;
+      goto error_out3;
+    }
+
     int status = amqp_ssl_socket_verify_hostname(self, host);
     if (status) {
       self->internal_error = 0;


### PR DESCRIPTION
At the moment, self->verify is only applicable to hostnames. If you turn verification off for testing purposes, validation is still performed against the peer. This change lets you turn off validation for both.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/180)
<!-- Reviewable:end -->
