### PR TITLE
Fixed timeval to milliseconds calculation error

### DIFF
--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -575,7 +575,7 @@ static int recv_with_timeout(amqp_connection_state_t state, uint64_t start, stru
       pfd.revents = 0;
 
       timeout_ms = timeout->tv_sec * AMQP_MS_PER_S +
-          timeout->tv_usec * AMQP_US_PER_MS;
+          timeout->tv_usec / AMQP_US_PER_MS;
 
       res = poll(&pfd, 1, timeout_ms);
 


### PR DESCRIPTION
milliseconds = seconds \* 1000 + microseconds / 1000
