### PR TITLE
Implement Auth Failure RabbitMQ extension

### DIFF
--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -2128,7 +2128,7 @@ AMQP_CALL amqp_encode_table(amqp_bytes_t encoded, amqp_table_t *input, size_t *o
  */
 AMQP_PUBLIC_FUNCTION
 int
-AMQP_CALL amqp_table_clone(amqp_table_t *original, amqp_table_t *clone, amqp_pool_t *pool);
+AMQP_CALL amqp_table_clone(const amqp_table_t *original, amqp_table_t *clone, amqp_pool_t *pool);
 
 /**
  * A message object

--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -2388,6 +2388,22 @@ AMQP_PUBLIC_FUNCTION
 amqp_table_t *
 amqp_get_server_properties(amqp_connection_state_t state);
 
+/**
+ * Get the client properties table
+ *
+ * Get the properties that were passed to the broker on connection.
+ *
+ * \param [in] state the connection object
+ * \return a pointer to an amqp_table_t containing the properties advertised
+ *  by the client on connection. The connection object owns the table, it
+ *  should not be modified.
+ *
+ * \since v0.7.0
+ */
+AMQP_PUBLIC_FUNCTION
+amqp_table_t *
+amqp_get_client_properties(amqp_connection_state_t state);
+
 AMQP_END_DECLS
 
 

--- a/librabbitmq/amqp_connection.c
+++ b/librabbitmq/amqp_connection.c
@@ -578,3 +578,9 @@ amqp_get_server_properties(amqp_connection_state_t state)
 {
   return &state->server_properties;
 }
+
+amqp_table_t *
+amqp_get_client_properties(amqp_connection_state_t state)
+{
+  return &state->client_properties;
+}

--- a/librabbitmq/amqp_mem.c
+++ b/librabbitmq/amqp_mem.c
@@ -250,3 +250,11 @@ amqp_pool_t *amqp_get_channel_pool(amqp_connection_state_t state, amqp_channel_t
 
   return NULL;
 }
+
+int amqp_bytes_equal(amqp_bytes_t r, amqp_bytes_t l) {
+  if (r.len == l.len &&
+      (r.bytes == l.bytes || 0 == memcmp(r.bytes, l.bytes, r.len))) {
+    return 1;
+  }
+  return 0;
+}

--- a/librabbitmq/amqp_private.h
+++ b/librabbitmq/amqp_private.h
@@ -366,4 +366,6 @@ AMQP_NORETURN
 void
 amqp_abort(const char *fmt, ...);
 
+int amqp_bytes_equal(amqp_bytes_t r, amqp_bytes_t l);
+
 #endif

--- a/librabbitmq/amqp_private.h
+++ b/librabbitmq/amqp_private.h
@@ -187,6 +187,7 @@ struct amqp_connection_state_t_ {
   amqp_rpc_reply_t most_recent_api_result;
 
   amqp_table_t server_properties;
+  amqp_table_t client_properties;
   amqp_pool_t properties_pool;
 };
 

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -1187,36 +1187,22 @@ static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
       goto error_res;
     }
 
-    default_properties[0].key = amqp_cstring_bytes("product");
-    default_properties[0].value.kind = AMQP_FIELD_KIND_UTF8;
-    default_properties[0].value.value.bytes =
-      amqp_cstring_bytes("rabbitmq-c");
 
-    /* version */
-    default_properties[1].key = amqp_cstring_bytes("version");
-    default_properties[1].value.kind = AMQP_FIELD_KIND_UTF8;
-    default_properties[1].value.value.bytes =
-        amqp_cstring_bytes(AMQP_VERSION_STRING);
 
-    /* platform */
-    default_properties[2].key = amqp_cstring_bytes("platform");
-    default_properties[2].value.kind = AMQP_FIELD_KIND_UTF8;
-    default_properties[2].value.value.bytes =
-        amqp_cstring_bytes(AMQ_PLATFORM);
-
-    /* copyright */
-    default_properties[3].key = amqp_cstring_bytes("copyright");
-    default_properties[3].value.kind = AMQP_FIELD_KIND_UTF8;
-    default_properties[3].value.value.bytes =
-        amqp_cstring_bytes(AMQ_COPYRIGHT);
-
-    default_properties[4].key = amqp_cstring_bytes("information");
-    default_properties[4].value.kind = AMQP_FIELD_KIND_UTF8;
-    default_properties[4].value.value.bytes =
-      amqp_cstring_bytes("See https://github.com/alanxz/rabbitmq-c");
+    default_properties[0] =
+        amqp_table_construct_utf8_entry("product", "rabbitmq-c");
+    default_properties[1] =
+        amqp_table_construct_utf8_entry("version", AMQP_VERSION_STRING);
+    default_properties[2] =
+        amqp_table_construct_utf8_entry("platform", AMQ_PLATFORM);
+    default_properties[3] =
+        amqp_table_construct_utf8_entry("copyright", AMQ_COPYRIGHT);
+    default_properties[4] = amqp_table_construct_utf8_entry(
+        "information", "See https://github.com/alanxz/rabbitmq-c");
 
     default_table.entries = default_properties;
-    default_table.num_entries = sizeof(default_properties) / sizeof(amqp_table_entry_t);
+    default_table.num_entries =
+        sizeof(default_properties) / sizeof(amqp_table_entry_t);
 
     if (0 == client_properties->num_entries) {
       s.client_properties = default_table;
@@ -1261,8 +1247,7 @@ static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
 
     s.mechanism = sasl_method_name(sasl_method);
     s.response = response_bytes;
-    s.locale.bytes = "en_US";
-    s.locale.len = 5;
+    s.locale = amqp_cstring_bytes("en_US");
 
     res = amqp_send_method(state, 0, AMQP_CONNECTION_START_OK_METHOD, &s);
     if (res < 0) {

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -43,6 +43,8 @@
 #endif
 
 #include "amqp_private.h"
+#include "amqp_socket.h"
+#include "amqp_table.h"
 #include "amqp_time.h"
 
 #include <assert.h>
@@ -1095,25 +1097,66 @@ amqp_rpc_reply_t amqp_get_rpc_reply(amqp_connection_state_t state)
   return state->most_recent_api_result;
 }
 
-
-static int amqp_table_contains_entry(const amqp_table_t *table,
-                                     const amqp_table_entry_t *entry)
-{
+/*
+ * Merge base and add tables. If the two tables contain an entry with the same
+ * key, the entry from the add table takes precedence. For entries that are both
+ * tables with the same key, the table is recursively merged.
+ */
+int amqp_merge_capabilities(const amqp_table_t *base, const amqp_table_t *add,
+                            amqp_table_t *result, amqp_pool_t *pool) {
   int i;
-  amqp_table_entry_t *current_entry;
+  int res;
+  amqp_pool_t temp_pool;
+  amqp_table_t temp_result;
+  assert(base != NULL);
+  assert(result != NULL);
+  assert(pool != NULL);
 
-  assert(table != NULL);
-  assert(entry != NULL);
-
-  current_entry = table->entries;
-
-  for (i = 0; i < table->num_entries; ++i, ++current_entry) {
-    if (0 == amqp_table_entry_cmp(current_entry, entry)) {
-      return 1;
-    }
+  if (NULL == add) {
+    return amqp_table_clone(base, result, pool);
   }
 
-  return 0;
+  init_amqp_pool(&temp_pool, 4096);
+  temp_result.num_entries = 0;
+  temp_result.entries =
+      amqp_pool_alloc(&temp_pool, sizeof(amqp_table_entry_t) *
+                                      (base->num_entries + add->num_entries));
+  if (NULL == temp_result.entries) {
+    res = AMQP_STATUS_NO_MEMORY;
+    goto error_out;
+  }
+  for (i = 0; i < base->num_entries; ++i) {
+    temp_result.entries[temp_result.num_entries] = base->entries[i];
+    temp_result.num_entries++;
+  }
+  for (i = 0; i < add->num_entries; ++i) {
+    amqp_table_entry_t *e =
+        amqp_table_get_entry_by_key(&temp_result, add->entries[i].key);
+    if (NULL != e) {
+      if (AMQP_FIELD_KIND_TABLE == add->entries[i].value.kind &&
+          AMQP_FIELD_KIND_TABLE == e->value.kind) {
+        int res;
+        amqp_table_entry_t *be =
+            amqp_table_get_entry_by_key(base, add->entries[i].key);
+
+        res = amqp_merge_capabilities(&be->value.value.table,
+                                      &add->entries[i].value.value.table,
+                                      &e->value.value.table, &temp_pool);
+        if (AMQP_STATUS_OK != res) {
+          goto error_out;
+        }
+      } else {
+        e->value = add->entries[i].value;
+      }
+    } else {
+      temp_result.entries[temp_result.num_entries] = add->entries[i];
+      temp_result.num_entries++;
+    }
+  }
+  res = amqp_table_clone(&temp_result, result, pool);
+error_out:
+  empty_amqp_pool(&temp_pool);
+  return res;
 }
 
 static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
@@ -1204,45 +1247,10 @@ static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
     default_table.num_entries =
         sizeof(default_properties) / sizeof(amqp_table_entry_t);
 
-    if (0 == client_properties->num_entries) {
-      s.client_properties = default_table;
-    } else {
-      /* Merge provided properties with our default properties:
-       * - Copy default properties.
-       * - Any provided property that doesn't have the same key as a default
-       *   property is also copied.
-       *
-       * TODO: if one of the default properties is a capabilities table, we will
-       * need to figure out how to merge this if the user provides a capabilites
-       * table
-       */
-      int i;
-      amqp_table_entry_t *current_entry;
-
-      s.client_properties.entries = amqp_pool_alloc(channel_pool,
-                                    sizeof(amqp_table_entry_t) * (default_table.num_entries + client_properties->num_entries));
-      if (NULL == s.client_properties.entries) {
-        res = AMQP_STATUS_NO_MEMORY;
-        goto error_res;
-      }
-      s.client_properties.num_entries = 0;
-
-      current_entry = s.client_properties.entries;
-
-      for (i = 0; i < default_table.num_entries; ++i) {
-        memcpy(current_entry, &default_table.entries[i], sizeof(amqp_table_entry_t));
-        s.client_properties.num_entries += 1;
-        ++current_entry;
-      }
-
-      for (i = 0; i < client_properties->num_entries; ++i) {
-        if (amqp_table_contains_entry(&default_table, &client_properties->entries[i])) {
-          continue;
-        }
-        memcpy(current_entry, &client_properties->entries[i], sizeof(amqp_table_entry_t));
-        s.client_properties.num_entries += 1;
-        ++current_entry;
-      }
+    res = amqp_merge_capabilities(&default_table, client_properties,
+                            &s.client_properties, channel_pool);
+    if (AMQP_STATUS_OK == res) {
+      goto error_res;
     }
 
     s.mechanism = sasl_method_name(sasl_method);

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -1211,8 +1211,10 @@ static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
   }
 
   {
-    amqp_table_entry_t default_properties[5];
+    amqp_table_entry_t default_properties[6];
     amqp_table_t default_table;
+    amqp_table_entry_t client_capabilities[1];
+    amqp_table_t client_capabilities_table;
     amqp_connection_start_ok_t s;
     amqp_pool_t *channel_pool;
     amqp_bytes_t response_bytes;
@@ -1230,7 +1232,12 @@ static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
       goto error_res;
     }
 
+    client_capabilities[0] =
+        amqp_table_construct_bool_entry("authentication_failure_close", 1);
 
+    client_capabilities_table.entries = client_capabilities;
+    client_capabilities_table.num_entries =
+        sizeof(client_capabilities) / sizeof(amqp_table_entry_t);
 
     default_properties[0] =
         amqp_table_construct_utf8_entry("product", "rabbitmq-c");
@@ -1242,6 +1249,8 @@ static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
         amqp_table_construct_utf8_entry("copyright", AMQ_COPYRIGHT);
     default_properties[4] = amqp_table_construct_utf8_entry(
         "information", "See https://github.com/alanxz/rabbitmq-c");
+    default_properties[5] = amqp_table_construct_table_entry(
+        "capabilities", &client_capabilities_table);
 
     default_table.entries = default_properties;
     default_table.num_entries =

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -1257,11 +1257,12 @@ static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
         sizeof(default_properties) / sizeof(amqp_table_entry_t);
 
     res = amqp_merge_capabilities(&default_table, client_properties,
-                            &s.client_properties, channel_pool);
-    if (AMQP_STATUS_OK == res) {
+                                  &state->client_properties, channel_pool);
+    if (AMQP_STATUS_OK != res) {
       goto error_res;
     }
 
+    s.client_properties = state->client_properties;
     s.mechanism = sasl_method_name(sasl_method);
     s.response = response_bytes;
     s.locale = amqp_cstring_bytes("en_US");

--- a/librabbitmq/amqp_socket.h
+++ b/librabbitmq/amqp_socket.h
@@ -177,6 +177,8 @@ amqp_simple_wait_frame_on_channel(amqp_connection_state_t state,
 int
 sasl_mechanism_in_list(amqp_bytes_t mechanisms, amqp_sasl_method_enum method);
 
+int amqp_merge_capabilities(const amqp_table_t *base, const amqp_table_t *add,
+                            amqp_table_t *result, amqp_pool_t *pool);
 AMQP_END_DECLS
 
 #endif /* AMQP_SOCKET_H */

--- a/librabbitmq/amqp_table.c
+++ b/librabbitmq/amqp_table.c
@@ -39,6 +39,7 @@
 #endif
 
 #include "amqp_private.h"
+#include "amqp_table.h"
 #include <assert.h>
 #include <stdint.h>
 #include <stdio.h>
@@ -611,4 +612,43 @@ amqp_table_clone(amqp_table_t *original, amqp_table_t *clone, amqp_pool_t *pool)
 
 error_out1:
   return res;
+}
+
+amqp_table_entry_t amqp_table_construct_utf8_entry(const char *key,
+                                                   const char *value) {
+  amqp_table_entry_t ret;
+  ret.key = amqp_cstring_bytes(key);
+  ret.value.kind = AMQP_FIELD_KIND_UTF8;
+  ret.value.value.bytes = amqp_cstring_bytes(value);
+  return ret;
+}
+
+amqp_table_entry_t amqp_table_construct_table_entry(const char *key,
+                                                    const amqp_table_t *value) {
+  amqp_table_entry_t ret;
+  ret.key = amqp_cstring_bytes(key);
+  ret.value.kind = AMQP_FIELD_KIND_TABLE;
+  ret.value.value.table = *value;
+  return ret;
+}
+
+amqp_table_entry_t amqp_table_construct_bool_entry(const char *key,
+                                                   const int value) {
+  amqp_table_entry_t ret;
+  ret.key = amqp_cstring_bytes(key);
+  ret.value.kind = AMQP_FIELD_KIND_BOOLEAN;
+  ret.value.value.boolean = value;
+  return ret;
+}
+
+amqp_table_entry_t *amqp_table_get_entry_by_key(const amqp_table_t *table,
+                                                const amqp_bytes_t key) {
+  int i;
+  assert(table != NULL);
+  for (i = 0; i < table->num_entries; ++i) {
+    if (amqp_bytes_equal(table->entries[i].key, key)) {
+      return &table->entries[i];
+    }
+  }
+  return NULL;
 }

--- a/librabbitmq/amqp_table.c
+++ b/librabbitmq/amqp_table.c
@@ -465,7 +465,7 @@ int amqp_table_entry_cmp(void const *entry1, void const *entry2)
 }
 
 static int
-amqp_field_value_clone(amqp_field_value_t *original, amqp_field_value_t *clone, amqp_pool_t *pool)
+amqp_field_value_clone(const amqp_field_value_t *original, amqp_field_value_t *clone, amqp_pool_t *pool)
 {
   int i;
   int res;
@@ -568,7 +568,7 @@ amqp_field_value_clone(amqp_field_value_t *original, amqp_field_value_t *clone, 
 
 
 static int
-amqp_table_entry_clone(amqp_table_entry_t *original, amqp_table_entry_t *clone, amqp_pool_t *pool)
+amqp_table_entry_clone(const amqp_table_entry_t *original, amqp_table_entry_t *clone, amqp_pool_t *pool)
 {
   if (0 == original->key.len) {
     return AMQP_STATUS_INVALID_PARAMETER;
@@ -585,7 +585,7 @@ amqp_table_entry_clone(amqp_table_entry_t *original, amqp_table_entry_t *clone, 
 }
 
 int
-amqp_table_clone(amqp_table_t *original, amqp_table_t *clone, amqp_pool_t *pool)
+amqp_table_clone(const amqp_table_t *original, amqp_table_t *clone, amqp_pool_t *pool)
 {
   int i;
   int res;

--- a/librabbitmq/amqp_table.h
+++ b/librabbitmq/amqp_table.h
@@ -1,0 +1,82 @@
+/* vim:set ft=c ts=2 sw=2 sts=2 et cindent: */
+/*
+ * ***** BEGIN LICENSE BLOCK *****
+ * Version: MIT
+ *
+ * Portions created by Alan Antonuk are Copyright (c) 2014 Alan Antonuk.
+ * All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ * ***** END LICENSE BLOCK *****
+ */
+#ifndef AMQP_TABLE_H
+#define AMQP_TABLE_H
+
+#include "amqp.h"
+#include "amqp_private.h"
+
+/**
+ * Initializes a table entry with utf-8 string type value.
+ *
+ * \param [in] key the table entry key. The string must remain valid for the
+ * life of the resulting amqp_table_entry_t.
+ * \param [in] value the string value. The string must remain valid for the life
+ * of the resulting amqp_table_entry_t.
+ * \returns An initialized table entry.
+ */
+amqp_table_entry_t amqp_table_construct_utf8_entry(const char *key,
+                                                   const char *value);
+
+/**
+ * Initializes a table entry with table type value.
+ *
+ * \param [in] key the table entry key. The string must remain value for the
+ * life of the resulting amqp_table_entry_t.
+ * \param [in] value the amqp_table_t value. The table must remain valid for the
+ * life of the resulting amqp_table_entry_t.
+ * \returns An initialized table entry.
+ */
+amqp_table_entry_t amqp_table_construct_table_entry(const char *key,
+                                                    const amqp_table_t *value);
+
+/**
+ * Initializes a table entry with boolean type value.
+ *
+ * \param [in] key the table entry key. The string must remain value for the
+ * life of the resulting amqp_table_entry_t.
+ * \param [in] value the boolean value. 0 means false, any other value is true.
+ * \returns An initialized table entry.
+ */
+amqp_table_entry_t amqp_table_construct_bool_entry(const char *key,
+                                                   const int value);
+
+/**
+ * Searches a table for an entry with a matching key.
+ *
+ * \param [in] table the table to search.
+ * \param [in] key the string to search with.
+ * \returns a pointer to the table entry in the table if a matching key can be
+ * found, NULL otherwise.
+ */
+amqp_table_entry_t *amqp_table_get_entry_by_key(const amqp_table_t *table,
+                                                const amqp_bytes_t key);
+
+#endif  /* AMQP_TABLE_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,3 +32,7 @@ add_test(status_enum test_status_enum)
 add_executable(test_sasl_mechanism test_sasl_mechanism.c)
 target_link_libraries(test_sasl_mechanism rabbitmq-static)
 add_test(sasl_mechanism test_sasl_mechanism)
+
+add_executable(test_merge_capabilities test_merge_capabilities.c)
+target_link_libraries(test_merge_capabilities rabbitmq-static)
+add_test(merge_capabilities test_merge_capabilities)

--- a/tests/test_merge_capabilities.c
+++ b/tests/test_merge_capabilities.c
@@ -1,0 +1,204 @@
+/* vim:set ft=c ts=2 sw=2 sts=2 et cindent: */
+/*
+ * Copyright 2015 Alan Antonuk. All Rights Reserved.
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "amqp_socket.h"
+#include "amqp_table.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+static int compare_bytes(amqp_bytes_t l, amqp_bytes_t r);
+static int compare_amqp_table_entry(amqp_table_entry_t result,
+                                    amqp_table_entry_t expect);
+static int compare_field_value(amqp_field_value_t result,
+                               amqp_field_value_t expect);
+static int compare_amqp_table(amqp_table_t* result, amqp_table_t* expect);
+
+static int compare_bytes(amqp_bytes_t l, amqp_bytes_t r) {
+  if (l.len == r.len &&
+      (l.bytes == r.bytes || 0 == memcmp(l.bytes, r.bytes, l.len))) {
+    return 1;
+  }
+  return 0;
+}
+
+static int compare_amqp_table_entry(amqp_table_entry_t result,
+                                    amqp_table_entry_t expect) {
+  if (!compare_bytes(result.key, expect.key)) {
+    return 0;
+  }
+  return compare_field_value(result.value, expect.value);
+}
+
+static int compare_field_value(amqp_field_value_t result,
+                               amqp_field_value_t expect) {
+  if (result.kind != expect.kind) {
+    return 0;
+  }
+  switch (result.kind) {
+    case AMQP_FIELD_KIND_BOOLEAN:
+      return result.value.boolean == expect.value.boolean;
+    case AMQP_FIELD_KIND_I8:
+      return result.value.i8 == expect.value.i8;
+    case AMQP_FIELD_KIND_U8:
+      return result.value.u8 == expect.value.u8;
+    case AMQP_FIELD_KIND_I16:
+      return result.value.i16 == expect.value.i16;
+    case AMQP_FIELD_KIND_U16:
+      return result.value.u16 == expect.value.u16;
+    case AMQP_FIELD_KIND_I32:
+      return result.value.i32 == expect.value.i32;
+    case AMQP_FIELD_KIND_U32:
+      return result.value.u32 == expect.value.u32;
+    case AMQP_FIELD_KIND_I64:
+      return result.value.i64 == expect.value.i64;
+    case AMQP_FIELD_KIND_U64:
+    case AMQP_FIELD_KIND_TIMESTAMP:
+      return result.value.u64 == expect.value.u64;
+    case AMQP_FIELD_KIND_F32:
+      return result.value.f32 == expect.value.f32;
+    case AMQP_FIELD_KIND_F64:
+      return result.value.f64 == expect.value.f64;
+    case AMQP_FIELD_KIND_DECIMAL:
+      return !memcmp(&result.value.decimal, &expect.value.decimal,
+                     sizeof(expect.value.decimal));
+    case AMQP_FIELD_KIND_UTF8:
+    case AMQP_FIELD_KIND_BYTES:
+      return compare_bytes(result.value.bytes, expect.value.bytes);
+    case AMQP_FIELD_KIND_ARRAY:
+      {
+        int i;
+        if (result.value.array.num_entries != expect.value.array.num_entries) {
+          return 0;
+        }
+        for (i = 0; i < result.value.array.num_entries; ++i) {
+          if (!compare_field_value(result.value.array.entries[i],
+                                   expect.value.array.entries[i])) {
+            return 0;
+          }
+        }
+        return 1;
+      }
+    case AMQP_FIELD_KIND_TABLE:
+      return compare_amqp_table(&result.value.table,
+                                &expect.value.table);
+    case AMQP_FIELD_KIND_VOID:
+      return 1;
+  }
+  return 1;
+}
+
+static int compare_amqp_table(amqp_table_t* result, amqp_table_t* expect) {
+  int i;
+
+  if (result->num_entries != expect->num_entries) {
+    return 0;
+  }
+
+  for (i = 0; i < expect->num_entries; ++i) {
+    if (!compare_amqp_table_entry(expect->entries[i], result->entries[i])) {
+      return 0;
+    }
+  }
+  return 1;
+}
+
+static void test_merge_capabilities(amqp_table_t* base, amqp_table_t* add,
+                                    amqp_table_t* expect) {
+  amqp_pool_t pool;
+  amqp_table_t result;
+  int res;
+  init_amqp_pool(&pool, 4096);
+
+  res = amqp_merge_capabilities(base, add, &result, &pool);
+  if (AMQP_STATUS_OK != res) {
+    fprintf(stderr, "amqp_merge_capabilities returned !ok: %d\n", res);
+    abort();
+  }
+
+  if (!compare_amqp_table(&result, expect)) {
+    fprintf(stderr, "amqp_merge_capabilities incorrect result.\n");
+    abort();
+  }
+  empty_amqp_pool(&pool);
+  return;
+}
+
+int main(void) {
+  {
+    amqp_table_t sub_base;
+    amqp_table_t sub_add;
+    amqp_table_t sub_expect;
+    amqp_table_t base;
+    amqp_table_t add;
+    amqp_table_t expect;
+
+    amqp_table_entry_t sub_base_entries[1];
+    amqp_table_entry_t sub_add_entries[2];
+    amqp_table_entry_t sub_expect_entries[2];
+
+    amqp_table_entry_t base_entries[3];
+    amqp_table_entry_t add_entries[3];
+    amqp_table_entry_t expect_entries[4];
+
+    sub_base_entries[0] = amqp_table_construct_utf8_entry("foo", "bar");
+    sub_base.num_entries = sizeof(sub_base_entries) / sizeof(amqp_table_entry_t);
+    sub_base.entries = sub_base_entries;
+
+    sub_add_entries[0] = amqp_table_construct_utf8_entry("something", "else");
+    sub_add_entries[1] = amqp_table_construct_utf8_entry("foo", "baz");
+    sub_add.num_entries = sizeof(sub_add_entries) / sizeof(amqp_table_entry_t);
+    sub_add.entries = sub_add_entries;
+
+    sub_expect_entries[0] = amqp_table_construct_utf8_entry("foo", "baz");
+    sub_expect_entries[1] = amqp_table_construct_utf8_entry("something", "else");
+    sub_expect.num_entries = sizeof(sub_expect_entries) / sizeof(amqp_table_entry_t);
+    sub_expect.entries = sub_expect_entries;
+
+    base_entries[0] = amqp_table_construct_utf8_entry("product", "1.0");
+    base_entries[1] = amqp_table_construct_utf8_entry("nooverride", "yeah");
+    base_entries[2] = amqp_table_construct_table_entry("props", &sub_base);
+    base.num_entries = sizeof(base_entries) / sizeof(amqp_table_entry_t);
+    base.entries = base_entries;
+
+    add_entries[0] = amqp_table_construct_bool_entry("bool_entry", 1);
+    add_entries[1] = amqp_table_construct_utf8_entry("product", "2.0");
+    add_entries[2] = amqp_table_construct_table_entry("props", &sub_add);
+    add.num_entries = sizeof(add_entries) / sizeof(amqp_table_entry_t);
+    add.entries = add_entries;
+
+    expect_entries[0] = amqp_table_construct_utf8_entry("product", "2.0"),
+    expect_entries[1] = amqp_table_construct_utf8_entry("nooverride", "yeah"),
+    expect_entries[2] = amqp_table_construct_table_entry("props", &sub_expect);
+    expect_entries[3] = amqp_table_construct_bool_entry("bool_entry", 1);
+    expect.num_entries = sizeof(expect_entries) / sizeof(amqp_table_entry_t);
+    expect.entries = expect_entries;
+
+    test_merge_capabilities(&base, &add, &expect);
+  }
+  fprintf(stderr, "ok\n");
+  return 0;
+}
+


### PR DESCRIPTION
Implement the [Auth Failure RabbitMQ extension](https://www.rabbitmq.com/auth-notification.html) to provide a more useful error message on authentication failure.

Features this depends on:
- [x] A way to correctly merge the default and provided client-properties table (And tests)
- [x] Providing `authentication_failure_close = true` entry in the default capabilities table.
- [x] Proper handling of a `connection.close` in `amqp_login_inner`.
- [ ] Add unit tests

Hopefully the first item will assist in implementing other rabbitmq extensions.

This fixes #182 