### PR TITLE
Correct htonll macro detection in CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,7 +103,7 @@ set(CMAKE_REQUIRED_LIBRARIES ${SOCKET_LIBRARIES})
 if (WIN32)
   check_symbol_exists(htonll Winsock2.h HAVE_HTONLL)
 else (WIN32)
-  check_function_exists(htonll HAVE_HTONLL)
+  check_symbol_exists(htonll arpa/inet.h HAVE_HTONLL)
 endif (WIN32)
 cmake_pop_check_state()
 


### PR DESCRIPTION
CMake's `check_function_exists()` only checks for a symbol being defined in a
library, and does not cover the instance where a function may be defined as a
macro a header. Use `check_symbol_exists()` to check arpa/inet.h header for symbol
existance of htonll.

This fixes #200
