### PR TITLE
ssl: Fix a bug that host name verification failure isn't reported

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -271,8 +271,8 @@ amqp_ssl_socket_open(void *base, const char *host, int port, struct timeval *tim
     goto error_out3;
   }
   if (self->verify) {
-    int status = amqp_ssl_socket_verify_hostname(self, host);
-    if (status) {
+    int verify_status = amqp_ssl_socket_verify_hostname(self, host);
+    if (verify_status) {
       self->internal_error = 0;
       status = AMQP_STATUS_SSL_HOSTNAME_VERIFY_FAILED;
       goto error_out3;


### PR DESCRIPTION
There is an unexpected local variable shadowing in
amqp_ssl_socket_open(). So the following code is meaningless
unexpectedly.

```
status = AMQP_STATUS_SSL_HOSTNAME_VERIFY_FAILED
```
