### PR TITLE
amqp-consume: support consuming N messages at a time

### DIFF
--- a/tools/doc/amqp-consume.xml
+++ b/tools/doc/amqp-consume.xml
@@ -160,6 +160,27 @@
                     </para>
                 </listitem>
             </varlistentry>
+            <varlistentry>
+                <term><option>-p</option></term>
+                <term><option>--prefetch-count</option>=<replaceable class="parameter">limit</replaceable></term>
+                <listitem>
+                    <para>
+                        Request the server to only send
+                        <replaceable class="parameter">limit</replaceable>
+                        messages at a time.
+                    </para>
+                    <para>
+                        If any value was passed to <option>--count</option>,
+                        the value passed to <option>--prefetch-count</option>
+                        should be smaller than that, or otherwise it will be
+                        ignored.
+                    </para>
+                    <para>
+                        If <option>-A</option>/<option>--no-ack</option> is
+                        passed, this option has no effect.
+                    </para>
+                </listitem>
+            </varlistentry>
         </variablelist>
     </refsect1>
 


### PR DESCRIPTION
If you have a single consumer C₁ and 10 messages are published, all 10
will be streamed to that one customer. Assume each message takes a few
minutes to be handled.

If a second consumer C₂ comes up before C₁ is able to process its first
message, it will stay idle until new messages are published, while C₁
will still have to process the other 9 messages after finishing with the
first one.

If both consumers were started with `--messages 1`, C₁ would only fetch
a single message, and start handling it; C₂ would start and already
receive the second message .
