### PR TITLE
Enable SSL support for tools too.

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -72,6 +72,10 @@ if (BUILD_TOOLS_DOCS)
   endif(XMLTO_FOUND)
 endif()
 
+if (ENABLE_SSL_SUPPORT)
+  add_definitions(-DWITH_SSL=1)
+endif()
+
 install(TARGETS amqp-publish amqp-get amqp-consume amqp-declare-queue amqp-delete-queue
 	RUNTIME DESTINATION bin
 	LIBRARY DESTINATION lib


### PR DESCRIPTION
In tools/common.c `#ifdef WITH_SSL` is used but never defined if SSL support is
desired.
