### PR TITLE
Fix issue: calling amqp_connection_close will crash (SIGSEGV) when a hea...

### DIFF
--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -784,7 +784,6 @@ beginrecv:
 
     if (AMQP_STATUS_TIMEOUT == res) {
       if (next_timestamp == state->next_recv_heartbeat) {
-        amqp_socket_close(state->socket);
         return AMQP_STATUS_HEARTBEAT_TIMEOUT;
       } else if (next_timestamp == timeout_timestamp) {
         return AMQP_STATUS_TIMEOUT;
@@ -940,7 +939,6 @@ int amqp_simple_wait_method(amqp_connection_state_t state,
   if (frame.channel != expected_channel
       || frame.frame_type != AMQP_FRAME_METHOD
       || frame.payload.method.id != expected_method) {
-    amqp_socket_close(state->socket);
     return AMQP_STATUS_WRONG_METHOD;
   }
   *output = frame.payload.method;


### PR DESCRIPTION
...rtbeat timeout happens using SSL.

When a heartbeat timeout happens, the amqp_socket_close will be called, the SSL Context will be freed.
At this time, if we call amqp_connection_close, it will issue an SSL_write with a NULL SSL Context, the application crashes.

We should let the application control when to close the socket.