### PR TITLE
CMake: skip getaddrinfo detection on iOS.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -65,6 +65,11 @@ cmake_push_check_state()
 if (WIN32)
   # Always use WinSock2 on Windows
   set(SOCKET_LIBRARIES ws2_32)
+elseif (IOS)
+  # try_compile() does not work with iOS.cmake. See:
+  # https://code.google.com/p/ios-cmake/issues/detail?id=1
+  # For now make the assumption that getaddrinfo/socket is in the default link
+  # libraries.
 else ()
   # Is it in the default link?
   CHECK_FUNCTION_EXISTS(getaddrinfo HAVE_GETADDRINFO)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -228,8 +228,16 @@ endif()
 
 find_package(Threads)
 
-option(BUILD_SHARED_LIBS "Build rabbitmq-c as a shared library" ON)
-option(BUILD_STATIC_LIBS "Build rabbitmq-c as a static library" OFF)
+set(_DEFAULT_BUILD_SHARED ON)
+set(_DEFAULT_BUILD_STATIC OFF)
+
+if (IOS)
+  set(_DEFAULT_BUILD_SHARED OFF)
+  set(_DEFAULT_BUILD_STATIC ON)
+endif()
+
+option(BUILD_SHARED_LIBS "Build rabbitmq-c as a shared library" ${_DEFAULT_BUILD_SHARED})
+option(BUILD_STATIC_LIBS "Build rabbitmq-c as a static library" ${_DEFAULT_BUILD_STATIC})
 
 option(BUILD_EXAMPLES "Build Examples" ON)
 option(BUILD_TOOLS "Build Tools (requires POPT Library)" ${POPT_FOUND})
@@ -265,7 +273,10 @@ if (NOT BUILD_SHARED_LIBS AND NOT BUILD_STATIC_LIBS)
 endif()
 
 if (WIN32 AND BUILD_STATIC_LIBS)
-  message(FATAL_ERROR "The rabbitmq-c library cannot be built as a static library on Win32. Set BUILD_STATIC_LIBS=OFF to get around this.")
+  message(FATAL_ERROR "rabbitmq-c cannot be built as a static library on Win32. Set BUILD_STATIC_LIBS=OFF to build.")
+endif()
+if (IOS AND BUILD_SHARED_LIBS)
+  message(FATAL_ERROR "rabbitmq-c cannot be built as a shared library on iOS. Set BUILD_SHARED_LIBS=OFF to build.")
 endif()
 
 add_subdirectory(librabbitmq)


### PR DESCRIPTION
getaddrinfo detection fails in CMake when trying to compile for iOS for some reason. Skip trying to detect it as its known to be there.