### PR TITLE
Use non-blocking sockets internally

### DIFF
--- a/librabbitmq/amqp_api.c
+++ b/librabbitmq/amqp_api.c
@@ -198,7 +198,7 @@ int amqp_basic_publish(amqp_connection_state_t state,
     }
 
     if (current_timestamp > state->next_recv_heartbeat) {
-      res = amqp_try_recv(state, current_timestamp);
+      res = amqp_try_recv(state);
       if (AMQP_STATUS_TIMEOUT == res) {
         return AMQP_STATUS_HEARTBEAT_TIMEOUT;
       } else if (AMQP_STATUS_OK != res) {

--- a/librabbitmq/amqp_connection.c
+++ b/librabbitmq/amqp_connection.c
@@ -476,7 +476,7 @@ int amqp_send_frame(amqp_connection_state_t state,
     iov[2].iov_base = &frame_end_byte;
     iov[2].iov_len = FOOTER_SIZE;
 
-    res = amqp_socket_writev(state->socket, iov, 3);
+    res = amqp_try_writev(state, iov, 3);
   } else {
     size_t out_frame_len;
     amqp_bytes_t encoded;
@@ -524,8 +524,8 @@ int amqp_send_frame(amqp_connection_state_t state,
 
     amqp_e32(out_frame, 3, out_frame_len);
     amqp_e8(out_frame, out_frame_len + HEADER_SIZE, AMQP_FRAME_END);
-    res = amqp_socket_send(state->socket, out_frame,
-                           out_frame_len + HEADER_SIZE + FOOTER_SIZE);
+    res = amqp_try_send(state, out_frame,
+                        out_frame_len + HEADER_SIZE + FOOTER_SIZE);
   }
 
   if (state->heartbeat > 0) {

--- a/librabbitmq/amqp_private.h
+++ b/librabbitmq/amqp_private.h
@@ -121,6 +121,15 @@ typedef enum amqp_connection_state_enum_ {
   CONNECTION_STATE_BODY
 } amqp_connection_state_enum;
 
+typedef enum amqp_status_private_enum_
+{
+  /* 0x00xx -> AMQP_STATUS_*/
+  /* 0x01xx -> AMQP_STATUS_TCP_* */
+  /* 0x02xx -> AMQP_STATUS_SSL_* */
+  AMQP_PRIVATE_STATUS_SOCKET_NEEDREAD =  -0x1301,
+  AMQP_PRIVATE_STATUS_SOCKET_NEEDWRITE = -0x1302
+} amqp_status_private_enum;
+
 /* 7 bytes up front, then payload, then 1 byte footer */
 #define HEADER_SIZE 7
 #define FOOTER_SIZE 1

--- a/librabbitmq/amqp_private.h
+++ b/librabbitmq/amqp_private.h
@@ -205,7 +205,7 @@ static inline uint64_t amqp_calc_next_recv_heartbeat(amqp_connection_state_t sta
   return cur + ((uint64_t)state->heartbeat * 2 * AMQP_NS_PER_S);
 }
 
-int amqp_try_recv(amqp_connection_state_t state, uint64_t current_time);
+int amqp_try_recv(amqp_connection_state_t state);
 
 static inline void *amqp_offset(void *data, size_t offset)
 {

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -338,12 +338,6 @@ int amqp_open_socket_noblock(char const *hostname,
     res = connect(sockfd, addr->ai_addr, addr->ai_addrlen);
 
     if (0 == res) {
-      /* Connected immediately, set to blocking mode again */
-      if (AMQP_STATUS_OK != amqp_os_socket_setsockblock(sockfd, 1)) {
-        last_error = AMQP_STATUS_SOCKET_ERROR;
-        continue;
-      }
-
       last_error = AMQP_STATUS_OK;
       break;
     }
@@ -388,12 +382,6 @@ int amqp_open_socket_noblock(char const *hostname,
           if (result != 0) {
             last_error = AMQP_STATUS_SOCKET_ERROR;
             break;
-          }
-
-          /* socket is ready to be written to, set to blocking mode again */
-          if (AMQP_STATUS_OK != amqp_os_socket_setsockblock(sockfd, 1)) {
-            last_error = AMQP_STATUS_SOCKET_ERROR;
-            continue;
           }
 
           last_error = AMQP_STATUS_OK;

--- a/librabbitmq/amqp_socket.h
+++ b/librabbitmq/amqp_socket.h
@@ -108,6 +108,9 @@ amqp_set_socket(amqp_connection_state_t state, amqp_socket_t *socket);
 ssize_t
 amqp_socket_writev(amqp_socket_t *self, struct iovec *iov, int iovcnt);
 
+ssize_t amqp_try_writev(amqp_connection_state_t state, struct iovec *iov,
+                        int iovcnt);
+
 /**
  * Send a message from a socket.
  *
@@ -124,6 +127,9 @@ amqp_socket_writev(amqp_socket_t *self, struct iovec *iov, int iovcnt);
  */
 ssize_t
 amqp_socket_send(amqp_socket_t *self, const void *buf, size_t len);
+
+ssize_t amqp_try_send(amqp_connection_state_t state, const void *buf,
+                      size_t len);
 
 /**
  * Receive a message from a socket.

--- a/librabbitmq/amqp_socket.h
+++ b/librabbitmq/amqp_socket.h
@@ -186,6 +186,12 @@ int
 amqp_open_socket_noblock(char const *hostname, int portnumber, struct timeval *timeout);
 
 int
+amqp_poll_read(int fd, uint64_t start, struct timeval *timeout);
+
+int
+amqp_poll_write(int fd, uint64_t start, struct timeval *timeout);
+
+int
 amqp_queue_frame(amqp_connection_state_t state, amqp_frame_t *frame);
 
 int

--- a/librabbitmq/amqp_socket.h
+++ b/librabbitmq/amqp_socket.h
@@ -33,6 +33,7 @@
 #define AMQP_SOCKET_H
 
 #include "amqp_private.h"
+#include "amqp_timer.h"
 
 AMQP_BEGIN_DECLS
 
@@ -185,11 +186,12 @@ amqp_socket_delete(amqp_socket_t *self);
 int
 amqp_open_socket_noblock(char const *hostname, int portnumber, struct timeval *timeout);
 
-int
-amqp_poll_read(int fd, uint64_t start, struct timeval *timeout);
+int amqp_open_socket_inner(char const *hostname, int portnumber,
+                           amqp_timer_t timeout);
 
-int
-amqp_poll_write(int fd, uint64_t start, struct timeval *timeout);
+int amqp_poll_read(int fd, amqp_timer_t timeout);
+
+int amqp_poll_write(int fd, amqp_timer_t timeout);
 
 int
 amqp_queue_frame(amqp_connection_state_t state, amqp_frame_t *frame);

--- a/librabbitmq/amqp_tcp_socket.c
+++ b/librabbitmq/amqp_tcp_socket.c
@@ -50,8 +50,6 @@ amqp_tcp_socket_send_inner(void *base, const void *buf, size_t len, int flags)
 {
   struct amqp_tcp_socket_t *self = (struct amqp_tcp_socket_t *)base;
   ssize_t res;
-  const char *buf_left = buf;
-  ssize_t len_left = len;
 
   if (-1 == self->sockfd) {
     return AMQP_STATUS_SOCKET_CLOSED;
@@ -62,24 +60,24 @@ amqp_tcp_socket_send_inner(void *base, const void *buf, size_t len, int flags)
 #endif
 
 start:
-  res = send(self->sockfd, buf_left, len_left, flags);
+  res = send(self->sockfd, buf, len, flags);
 
   if (res < 0) {
     self->internal_error = amqp_os_socket_error();
-    if (EINTR == self->internal_error) {
-      goto start;
-    } else {
-      res = AMQP_STATUS_SOCKET_ERROR;
+    switch (self->internal_error) {
+      case EINTR:
+        goto start;
+      case EWOULDBLOCK:
+#if defined(EAGAIN) && EAGAIN != EWOULDBLOCK
+      case EAGAIN:
+#endif
+        res = AMQP_PRIVATE_STATUS_SOCKET_NEEDWRITE;
+        break;
+      default:
+        res = AMQP_STATUS_SOCKET_ERROR;
     }
   } else {
-    if (res == len_left) {
-      self->internal_error = 0;
-      res = AMQP_STATUS_OK;
-    } else {
-      buf_left += res;
-      len_left -= res;
-      goto start;
-    }
+    self->internal_error = 0;
   }
 
   return res;
@@ -109,27 +107,15 @@ amqp_tcp_socket_writev(void *base, struct iovec *iov, int iovcnt)
     if (WSASend(self->sockfd, (LPWSABUF)iov, iovcnt, &res, 0, NULL, NULL) ==
         0) {
       self->internal_error = 0;
-      ret = AMQP_STATUS_OK;
+      ret = res;
     } else {
       self->internal_error = WSAGetLastError();
-      ret = AMQP_STATUS_SOCKET_ERROR;
-    }
-    return ret;
-  }
-
-#elif defined(MSG_MORE)
-  {
-    int i;
-    for (i = 0; i < iovcnt - 1; ++i) {
-      ret = amqp_tcp_socket_send_inner(self, iov[i].iov_base, iov[i].iov_len,
-                                       MSG_MORE);
-      if (ret != AMQP_STATUS_OK) {
-        goto exit;
+      if (WSAEWOULDBLOCK == self->internal_error) {
+        ret = AMQP_PRIVATE_STATUS_SOCKET_NEEDWRITE;
+      } else {
+        ret = AMQP_STATUS_SOCKET_ERROR;
       }
     }
-    ret = amqp_tcp_socket_send_inner(self, iov[i].iov_base, iov[i].iov_len, 0);
-
-  exit:
     return ret;
   }
 
@@ -146,38 +132,23 @@ amqp_tcp_socket_writev(void *base, struct iovec *iov, int iovcnt)
     }
 
   start:
-    ret = writev(self->sockfd, iov_left, iovcnt_left);
+    ret = writev(self->sockfd, iov, iovcnt);
 
     if (ret < 0) {
       self->internal_error = amqp_os_socket_error();
-      if (EINTR == self->internal_error) {
-        goto start;
-      } else {
-        self->internal_error = amqp_os_socket_error();
-        ret = AMQP_STATUS_SOCKET_ERROR;
-      }
-    } else {
-      if (ret == len_left) {
-        self->internal_error = 0;
-        ret = AMQP_STATUS_OK;
-      } else {
-        len_left -= ret;
-        for (i = 0; i < iovcnt_left; ++i) {
-          if (ret < (ssize_t)iov_left[i].iov_len) {
-            iov_left[i].iov_base = ((char *)iov_left[i].iov_base) + ret;
-            iov_left[i].iov_len -= ret;
-
-            iovcnt_left -= i;
-            iov_left += i;
-            break;
-          } else {
-            ret -= iov_left[i].iov_len;
-          }
-        }
-        goto start;
+      switch (self->internal_error) {
+        case EINTR:
+          goto start;
+        case EWOULDBLOCK:
+#if defined(EAGAIN) && EAGAIN != EWOULDBLOCK
+        case EAGAIN:
+#endif
+          ret = AMQP_PRIVATE_STATUS_SOCKET_NEEDWRITE;
+          break;
+        default:
+          ret = AMQP_STATUS_SOCKET_ERROR;
       }
     }
-
     return ret;
   }
 
@@ -205,7 +176,7 @@ amqp_tcp_socket_writev(void *base, struct iovec *iov, int iovcnt)
     bufferp = self->buffer;
     for (i = 0; i < iovcnt; ++i) {
       memcpy(bufferp, iov[i].iov_base, iov[i].iov_len);
-      bufferp += iov[i].iov_len;
+      bufferp = (char*)bufferp + iov[i].iov_len;
     }
 
     ret = amqp_tcp_socket_send_inner(self, self->buffer, bytes, 0);

--- a/librabbitmq/amqp_timer.h
+++ b/librabbitmq/amqp_timer.h
@@ -44,24 +44,24 @@
 #define AMQP_NS_PER_MS 1000000
 #define AMQP_NS_PER_US 1000
 
-#define AMQP_INIT_TIMER(structure) { \
-  structure.current_timestamp = 0;   \
-  structure.timeout_timestamp = 0;   \
-}
-
 typedef struct amqp_timer_t_ {
-  uint64_t current_timestamp;
-  uint64_t timeout_timestamp;
-  uint64_t ns_until_next_timeout;
-  struct timeval tv;
+  uint64_t expiration_ns;
 } amqp_timer_t;
 
 /* Gets a monotonic timestamp in ns */
 uint64_t
 amqp_get_monotonic_timestamp(void);
 
-/* Prepare timeout value and modify timer state based on timer state. */
-int
-amqp_timer_update(amqp_timer_t *timer, struct timeval *timeout);
+/* Start an amqp_timer_t set to expire timeout from now. */
+int amqp_timer_start(amqp_timer_t *timer, struct timeval *timeout);
+
+amqp_timer_t amqp_timer_start_immediate(void);
+
+amqp_timer_t amqp_timer_start_infinite(void);
+
+/* Get the (positive) number of ms left on the timer, or -1 for an infinite
+ * timer, or AMQP_STATUS_TIMEOUT on time out, or AMQP_STATUS_TIMER_FAILURE on
+ * failure. */
+int amqp_timer_ms_left(amqp_timer_t timer);
 
 #endif /* AMQP_TIMER_H */


### PR DESCRIPTION
Use non-blocking sockets internally. This will allow support for handling heartbeats in cases where `send()` may block.

- [x] set socket to non-blocking after opening the socket
- [x] add support in plain-TCP read-path (`recv()`) for non-blocking sockets
- [x] add support in plain-TCP write-path (`send()` `writev()`) for non-blocking sockets
- [x] add support for SSL sockets in read and write
- [ ] ~~add support for heartbeats in send path.~~ Moved to new issue: #259

Fixes #227 