### PR TITLE
fix WSAEINVAL WSAPoll due to POLERR in events

### DIFF
--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -360,7 +360,7 @@ int amqp_open_socket_noblock(char const *hostname,
           int timeout_ms;
 
           pfd.fd = sockfd;
-          pfd.events = POLLERR | POLLOUT;
+          pfd.events = POLLOUT;
           pfd.revents = 0;
 
           timer_error = amqp_timer_update(&timer, timeout);


### PR DESCRIPTION
POLLERR is meaningless in the events field, it will be set in the revents whenever the corresponding condition is true.
Moreover the WSAPoll fails if there is something other than these flags in the events: POLLPRI, POLLRDBAND, POLLRDNORM, POLLWRNORM.

At least it is so in Windows 7 x64