### PR TITLE
Squash warnings about static initializers in tools.

### DIFF
--- a/tools/consume.c
+++ b/tools/consume.c
@@ -176,6 +176,7 @@ static void do_consume(amqp_connection_state_t conn, amqp_bytes_t queue,
     amqp_frame_t frame;
     struct pipeline pl;
     uint64_t delivery_tag;
+    amqp_basic_deliver_t *deliver;
     int res = amqp_simple_wait_frame(conn, &frame);
     die_amqp_error(res, "waiting for header frame");
 
@@ -184,8 +185,7 @@ static void do_consume(amqp_connection_state_t conn, amqp_bytes_t queue,
       continue;
     }
 
-    amqp_basic_deliver_t *deliver
-      = (amqp_basic_deliver_t *)frame.payload.method.decoded;
+    deliver = (amqp_basic_deliver_t *)frame.payload.method.decoded;
     delivery_tag = deliver->delivery_tag;
 
     pipeline(argv, &pl);
@@ -205,14 +205,14 @@ int main(int argc, const char **argv)
   poptContext opts;
   amqp_connection_state_t conn;
   const char *const *cmd_argv;
-  char *queue = NULL;
-  char *exchange = NULL;
-  char *routing_key = NULL;
-  int declare = 0;
-  int exclusive = 0;
-  int no_ack = 0;
-  int count = -1;
-  int prefetch_count = -1;
+  static char *queue = NULL;
+  static char *exchange = NULL;
+  static char *routing_key = NULL;
+  static int declare = 0;
+  static int exclusive = 0;
+  static int no_ack = 0;
+  static int count = -1;
+  static int prefetch_count = -1;
   amqp_bytes_t queue_bytes;
 
   struct poptOption options[] = {

--- a/tools/declare_queue.c
+++ b/tools/declare_queue.c
@@ -48,8 +48,8 @@
 int main(int argc, const char **argv)
 {
   amqp_connection_state_t conn;
-  char *queue = NULL;
-  int durable = 0;
+  static char *queue = NULL;
+  static int durable = 0;
 
   struct poptOption options[] = {
     INCLUDE_OPTIONS(connect_options),

--- a/tools/delete_queue.c
+++ b/tools/delete_queue.c
@@ -48,9 +48,9 @@
 int main(int argc, const char **argv)
 {
   amqp_connection_state_t conn;
-  char *queue = NULL;
-  int if_unused = 0;
-  int if_empty = 0;
+  static char *queue = NULL;
+  static int if_unused = 0;
+  static int if_empty = 0;
 
   struct poptOption options[] = {
     INCLUDE_OPTIONS(connect_options),

--- a/tools/get.c
+++ b/tools/get.c
@@ -59,7 +59,7 @@ static int do_get(amqp_connection_state_t conn, char *queue)
 int main(int argc, const char **argv)
 {
   amqp_connection_state_t conn;
-  char *queue = NULL;
+  static char *queue = NULL;
   int got_something;
 
   struct poptOption options[] = {

--- a/tools/publish.c
+++ b/tools/publish.c
@@ -60,16 +60,16 @@ static void do_publish(amqp_connection_state_t conn,
 int main(int argc, const char **argv)
 {
   amqp_connection_state_t conn;
-  char *exchange = NULL;
-  char *routing_key = NULL;
-  char *content_type = NULL;
-  char *content_encoding = NULL;
-  char *reply_to = NULL;
-  char *body = NULL;
+  static char *exchange = NULL;
+  static char *routing_key = NULL;
+  static char *content_type = NULL;
+  static char *content_encoding = NULL;
+  static char *reply_to = NULL;
+  static char *body = NULL;
   amqp_basic_properties_t props;
   amqp_bytes_t body_bytes;
-  int delivery = 1; /* non-persistent by default */
-  int line_buffered = 0;
+  static int delivery = 1; /* non-persistent by default */
+  static int line_buffered = 0;
 
   struct poptOption options[] = {
     INCLUDE_OPTIONS(connect_options),


### PR DESCRIPTION
Reduces the number of silly warnings when compiling on C89 compilers.