### PR TITLE
Build enhancements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
 
 # Run the Build script
 script:
-  - if [ ${COVERITY_SCAN_BRANCH} != 1 ]; then
+  - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then
       case $BUILD_SYSTEM in
         cmake)
           cmake .. -DCMAKE_INSTALL_PREFIX=`pwd`/_install &&

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,17 @@ include(CheckSymbolExists)
 include(CheckLibraryExists)
 include(CMakePushCheckState)
 include(GNUInstallDirs)
+include(CheckCCompilerFlag)
+
+CHECK_C_COMPILER_FLAG("-std=c99" HAVE_C99)
+if (HAVE_C99)
+  CHECK_C_COMPILER_FLAG("-std=gnu99" HAVE_GNU99)
+  if (HAVE_GNU99)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+  else ()
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=c99")
+  endif()
+endif()
 
 # Detect if we need to link against a socket library:
 cmake_push_check_state()

--- a/examples/unix/platform_utils.c
+++ b/examples/unix/platform_utils.c
@@ -34,11 +34,8 @@
  * ***** END LICENSE BLOCK *****
  */
 
-/* For usleep */
-#define _BSD_SOURCE
-
 #include <stdint.h>
-
+#include <time.h>
 #include <sys/time.h>
 #include <unistd.h>
 
@@ -51,5 +48,8 @@ uint64_t now_microseconds(void)
 
 void microsleep(int usec)
 {
-  usleep(usec);
+  struct timespec req;
+  req.tv_sec = 0;
+  req.tv_nsec = 1000 * usec;
+  nanosleep(&req, NULL);
 }

--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -242,7 +242,7 @@ AMQP_BEGIN_DECLS
  * 0x02030401
  *
  * \sa amqp_version_number() AMQP_VERSION_MAJOR, AMQP_VERSION_MINOR,
- *     AMQP_VERSION_PATCH, AMQP_VERSION_IS_RELEASE
+ *     AMQP_VERSION_PATCH, AMQP_VERSION_IS_RELEASE, AMQP_VERSION_CODE
  *
  * \since v0.4.0
  */
@@ -250,6 +250,24 @@ AMQP_BEGIN_DECLS
                       (AMQP_VERSION_MINOR << 16) | \
                       (AMQP_VERSION_PATCH << 8)  | \
                       (AMQP_VERSION_IS_RELEASE))
+
+/**
+ * \def AMQP_VERSION_CODE
+ *
+ * Helper macro to geneate a packed version code suitable for
+ * comparison with AMQP_VERSION.
+ *
+ * \sa amqp_version_number() AMQP_VERSION_MAJOR, AMQP_VERSION_MINOR,
+ *     AMQP_VERSION_PATCH, AMQP_VERSION_IS_RELEASE, AMQP_VERSION
+ *
+ * \since v0.6.1
+ */
+#define AMQP_VERSION_CODE(major, minor, patch, release) \
+    ((major << 24) | \
+     (minor << 16) | \
+     (patch << 8)  | \
+     (release))
+
 
 /** \cond HIDE_FROM_DOXYGEN */
 #define AMQ_STRINGIFY(s) AMQ_STRINGIFY_HELPER(s)

--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -229,6 +229,24 @@ AMQP_BEGIN_DECLS
 
 
 /**
+ * \def AMQP_VERSION_CODE
+ *
+ * Helper macro to geneate a packed version code suitable for
+ * comparison with AMQP_VERSION.
+ *
+ * \sa amqp_version_number() AMQP_VERSION_MAJOR, AMQP_VERSION_MINOR,
+ *     AMQP_VERSION_PATCH, AMQP_VERSION_IS_RELEASE, AMQP_VERSION
+ *
+ * \since v0.6.1
+ */
+#define AMQP_VERSION_CODE(major, minor, patch, release) \
+    ((major << 24) | \
+     (minor << 16) | \
+     (patch << 8)  | \
+     (release))
+
+
+/**
  * \def AMQP_VERSION
  *
  * Packed version number
@@ -246,28 +264,10 @@ AMQP_BEGIN_DECLS
  *
  * \since v0.4.0
  */
-#define AMQP_VERSION ((AMQP_VERSION_MAJOR << 24) | \
-                      (AMQP_VERSION_MINOR << 16) | \
-                      (AMQP_VERSION_PATCH << 8)  | \
-                      (AMQP_VERSION_IS_RELEASE))
-
-/**
- * \def AMQP_VERSION_CODE
- *
- * Helper macro to geneate a packed version code suitable for
- * comparison with AMQP_VERSION.
- *
- * \sa amqp_version_number() AMQP_VERSION_MAJOR, AMQP_VERSION_MINOR,
- *     AMQP_VERSION_PATCH, AMQP_VERSION_IS_RELEASE, AMQP_VERSION
- *
- * \since v0.6.1
- */
-#define AMQP_VERSION_CODE(major, minor, patch, release) \
-    ((major << 24) | \
-     (minor << 16) | \
-     (patch << 8)  | \
-     (release))
-
+#define AMQP_VERSION AMQP_VERSION_CODE(AMQP_VERSION_MAJOR, \
+                                       AMQP_VERSION_MINOR, \
+                                       AMQP_VERSION_PATCH, \
+                                       AMQP_VERSION_IS_RELEASE)
 
 /** \cond HIDE_FROM_DOXYGEN */
 #define AMQ_STRINGIFY(s) AMQ_STRINGIFY_HELPER(s)

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -960,7 +960,8 @@ int amqp_simple_wait_method(amqp_connection_state_t state,
                             amqp_method_number_t expected_method,
                             amqp_method_t *output)
 {
-  amqp_method_number_t expected_methods[] = { expected_method, 0 };
+  amqp_method_number_t expected_methods[] = { 0, 0 };
+  expected_methods[0] = expected_method;
   return amqp_simple_wait_method_list(state, expected_channel, expected_methods,
                                       output);
 }

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -1145,7 +1145,6 @@ int amqp_merge_capabilities(const amqp_table_t *base, const amqp_table_t *add,
     if (NULL != e) {
       if (AMQP_FIELD_KIND_TABLE == add->entries[i].value.kind &&
           AMQP_FIELD_KIND_TABLE == e->value.kind) {
-        int res;
         amqp_table_entry_t *be =
             amqp_table_get_entry_by_key(base, add->entries[i].key);
 


### PR DESCRIPTION
 	amqp: helper macro to generate AMQP_VERSION code

This patch addresses version check inconvenience when building with multiple rabbitmq-c versions

 	examples: replace usleep() with nanosleep()

This one resolves deprecation warnings when building on a system with glibc recent enough