### PR TITLE
OpenSSL handling fixes

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -300,7 +300,7 @@ amqp_ssl_socket_open(void *base, const char *host, int port, struct timeval *tim
 
 start_connect:
   status = SSL_connect(self->ssl);
-  if (!status) {
+  if (status != 1) {
     self->internal_error = SSL_get_error(self->ssl, status);
     switch (self->internal_error) {
       case SSL_ERROR_WANT_READ:

--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -278,6 +278,10 @@ amqp_ssl_socket_open(void *base, const char *host, int port, struct timeval *tim
     goto exit;
   }
 
+  if (self->verify) {
+    SSL_set_verify(self->ssl, SSL_VERIFY_PEER, NULL);
+  }
+
   status = amqp_time_from_now(&deadline, timeout);
   if (AMQP_STATUS_OK != status) {
     return status;


### PR DESCRIPTION
	amqp_openssl: fix SSL_connect() status check

This patch fixes a scenario in which the handshake is finished prematurely due to incorrect SSL_connect() return value check. The documentation available here https://www.openssl.org/docs/ssl/SSL_connect.html states that negative return value may indicate the need to continue the operation for non-blocking BIOs (implicitly any non-blocking IO, even without BIO wrappers).

	amqp_openssl: explicitly set SSL_VERIFY_PEER

This patch enables explicit peer verification if host verification is on, but really I'd be willing to always enable peer verification, regardless of host verification setting. There's no need to proceed with the handshake if one of the certificates fails to verify.