### PR TITLE
amqp_openssl: *_ssl_send() should return number of bytes sent

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -113,7 +113,6 @@ amqp_ssl_socket_send(void *base,
     }
   } else {
     self->internal_error = 0;
-    res = AMQP_STATUS_OK;
   }
 
   return res;


### PR DESCRIPTION
Function amqp_ssl_socket_send() should return the number of bytes
written. Retruning AMQP_STATUS_OK on success will cause all
amqp_socket_send() with SSL socket implementation to behave incorrectly.