### PR TITLE
Send performance improvements.

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -76,11 +76,8 @@ struct amqp_ssl_socket_t {
   int internal_error;
 };
 
-static ssize_t
-amqp_ssl_socket_send(void *base,
-                     const void *buf,
-                     size_t len)
-{
+static ssize_t amqp_ssl_socket_send(void *base, const void *buf, size_t len,
+                                    int flags) {
   struct amqp_ssl_socket_t *self = (struct amqp_ssl_socket_t *)base;
   ssize_t res;
   if (-1 == self->sockfd) {

--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -70,8 +70,6 @@ struct amqp_ssl_socket_t {
   SSL_CTX *ctx;
   int sockfd;
   SSL *ssl;
-  char *buffer;
-  size_t length;
   amqp_boolean_t verify;
   int internal_error;
 };
@@ -402,7 +400,6 @@ amqp_ssl_socket_delete(void *base)
     amqp_ssl_socket_close(self);
 
     SSL_CTX_free(self->ctx);
-    free(self->buffer);
     free(self);
   }
   destroy_openssl();

--- a/librabbitmq/amqp_private.h
+++ b/librabbitmq/amqp_private.h
@@ -369,4 +369,6 @@ amqp_abort(const char *fmt, ...);
 
 int amqp_bytes_equal(amqp_bytes_t r, amqp_bytes_t l);
 
+int amqp_send_frame_inner(amqp_connection_state_t state,
+                          const amqp_frame_t *frame, int flags);
 #endif

--- a/librabbitmq/amqp_socket.h
+++ b/librabbitmq/amqp_socket.h
@@ -37,6 +37,11 @@
 
 AMQP_BEGIN_DECLS
 
+typedef enum {
+  AMQP_SF_NONE = 0,
+  AMQP_SF_MORE = 1
+} amqp_socket_flag_enum;
+
 int
 amqp_os_socket_error(void);
 
@@ -44,7 +49,7 @@ int
 amqp_os_socket_close(int sockfd);
 
 /* Socket callbacks. */
-typedef ssize_t (*amqp_socket_send_fn)(void *, const void *, size_t);
+typedef ssize_t (*amqp_socket_send_fn)(void *, const void *, size_t, int);
 typedef ssize_t (*amqp_socket_recv_fn)(void *, void *, size_t, int);
 typedef int (*amqp_socket_open_fn)(void *, const char *, int, struct timeval *);
 typedef int (*amqp_socket_close_fn)(void *);
@@ -91,14 +96,15 @@ amqp_set_socket(amqp_connection_state_t state, amqp_socket_t *socket);
  * \param [in,out] self A socket object.
  * \param [in] buf A buffer to read from.
  * \param [in] len The number of bytes in \e buf.
+ * \param [in]
  *
  * \return AMQP_STATUS_OK on success. amqp_status_enum value otherwise
  */
 ssize_t
-amqp_socket_send(amqp_socket_t *self, const void *buf, size_t len);
+amqp_socket_send(amqp_socket_t *self, const void *buf, size_t len, int flags);
 
 ssize_t amqp_try_send(amqp_connection_state_t state, const void *buf,
-                      size_t len, amqp_time_t deadline);
+                      size_t len, amqp_time_t deadline, int flags);
 
 /**
  * Receive a message from a socket.
@@ -163,6 +169,9 @@ int amqp_poll_read(int fd, amqp_time_t deadline);
 /* Wait up to deadline for fd to become writeable */
 int amqp_poll_write(int fd, amqp_time_t deadline);
 
+int amqp_send_method_inner(amqp_connection_state_t state,
+                           amqp_channel_t channel, amqp_method_number_t id,
+                           void *decoded, int flags);
 int
 amqp_queue_frame(amqp_connection_state_t state, amqp_frame_t *frame);
 

--- a/librabbitmq/amqp_tcp_socket.c
+++ b/librabbitmq/amqp_tcp_socket.c
@@ -42,25 +42,31 @@ struct amqp_tcp_socket_t {
 
 
 static ssize_t
-amqp_tcp_socket_send(void *base, const void *buf, size_t len)
+amqp_tcp_socket_send(void *base, const void *buf, size_t len, int flags)
 {
   struct amqp_tcp_socket_t *self = (struct amqp_tcp_socket_t *)base;
   ssize_t res;
-  int flags = 0;
+  int flagz = 0;
 
   if (-1 == self->sockfd) {
     return AMQP_STATUS_SOCKET_CLOSED;
   }
 
 #ifdef MSG_NOSIGNAL
-  flags |= MSG_NOSIGNAL;
+  flagz |= MSG_NOSIGNAL;
+#endif
+
+#if defined(MSG_MORE)
+  if (flags & AMQP_SF_MORE) {
+    flagz |= MSG_MORE;
+  }
 #endif
 
 start:
 #ifdef _WIN32
-  res = send(self->sockfd, buf, (int)len, flags);
+  res = send(self->sockfd, buf, (int)len, flagz);
 #else
-  res = send(self->sockfd, buf, len, flags);
+  res = send(self->sockfd, buf, len, flagz);
 #endif
 
   if (res < 0) {

--- a/librabbitmq/amqp_tcp_socket.c
+++ b/librabbitmq/amqp_tcp_socket.c
@@ -38,8 +38,6 @@
 struct amqp_tcp_socket_t {
   const struct amqp_socket_class_t *klass;
   int sockfd;
-  void *buffer;
-  size_t buffer_length;
   int internal_error;
   int state;
 };
@@ -196,7 +194,6 @@ amqp_tcp_socket_delete(void *base)
 
   if (self) {
     amqp_tcp_socket_close(self);
-    free(self->buffer);
     free(self);
   }
 }


### PR DESCRIPTION
This is an attempt to improve the basic.publish performance by indicating to the OS that the basic.publish, header, and body frames are all a part of the same message so they should be sent out as one packet if the OS determines it makes sense.

Currently this PR only covers Linux using the `MSG_MORE` flag to the `send()` call.

Evaluating this running on Ubuntu 14.04.02 running in a VM on Mac OS X 10.11, talking to RabbitMQ 3.5.2 running different machine Mac OS X 10.11 connected over a 100mb ethernet connection.

Comparing this PR against the v0.6.0 tag using the amqp_producer example.

Looking at the packets sent using `tcpdump` for the first few messages, the packets are sent as I would expect for both methods, however, after the first few message are sent, the kernel start combining messages into larger packets so the performance of the two methods ends up being nearly identical (both in terms of msg/s and packets sent).