### PR TITLE
Fix build on OpenBSD

### DIFF
--- a/librabbitmq/amqp_tcp_socket.c
+++ b/librabbitmq/amqp_tcp_socket.c
@@ -35,6 +35,8 @@
 # endif
 # include <WinSock2.h>
 #else
+# include <sys/socket.h>
+# include <netinet/in.h>
 # include <netinet/tcp.h>
 #endif
 #include <stdio.h>


### PR DESCRIPTION
We need to include &lt;sys/socket.h&gt; for setsockopt definition and also &lt;netinet/in.h&gt; for the IPPROTO_TCP definition used in setsockopt.