### PR TITLE
Win32: check exceptfds in select when connecting

### DIFF
--- a/librabbitmq/amqp_socket.h
+++ b/librabbitmq/amqp_socket.h
@@ -41,7 +41,8 @@ typedef enum {
   AMQP_SF_NONE = 0,
   AMQP_SF_MORE = 1,
   AMQP_SF_POLLIN = 2,
-  AMQP_SF_POLLOUT = 4
+  AMQP_SF_POLLOUT = 4,
+  AMQP_SF_POLLERR = 8
 } amqp_socket_flag_enum;
 
 int


### PR DESCRIPTION
When doing a nonblocking connect() on win32, select() reports failure using
exceptfds instead of writefds. Allow this narrow case when doing a non-blocking
connect on Win32.

See:
https://msdn.microsoft.com/en-us/library/windows/desktop/ms740141(v=vs.85).aspx

Fixes #297