### PR TITLE
Lib: allow selection of desired TLS version

### DIFF
--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -726,7 +726,9 @@ typedef enum amqp_status_enum_
   AMQP_STATUS_BROKER_UNSUPPORTED_SASL_METHOD = -0x0013, /**< Broker does not
                                                           support the requested
                                                           SASL mechanism */
-  _AMQP_STATUS_NEXT_VALUE =               -0x0014, /**< Internal value */
+  AMQP_STATUS_UNSUPPORTED =               -0x0014, /**< Parameter is unsupported
+                                                     in this version */
+  _AMQP_STATUS_NEXT_VALUE =               -0x0015, /**< Internal value */
 
   AMQP_STATUS_TCP_ERROR =                 -0x0100, /**< A generic TCP error
                                                         occurred */

--- a/librabbitmq/amqp_api.c
+++ b/librabbitmq/amqp_api.c
@@ -82,7 +82,8 @@ static const char *base_error_strings[] = {
   "unexpected protocol state",          /* AMQP_STATUS_UNEXPECTED STATE         -0x0010 */
   "socket is closed",                   /* AMQP_STATUS_SOCKET_CLOSED            -0x0011 */
   "socket already open",                /* AMQP_STATUS_SOCKET_INUSE             -0x0012 */
-  "unsupported sasl method requested"   /* AMQP_STATUS_BROKER_UNSUPPORTED_SASL_METHOD -0x0013 */
+  "unsupported sasl method requested",  /* AMQP_STATUS_BROKER_UNSUPPORTED_SASL_METHOD -0x0013 */
+  "parameter value is unsupported"      /* AMQP_STATUS_UNSUPPORTED -0x0014 */
 };
 
 static const char *tcp_error_strings[] = {

--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -425,6 +425,8 @@ amqp_ssl_socket_new(amqp_connection_state_t state)
   if (!self->ctx) {
     goto error;
   }
+  /* Disable SSLv2 and SSLv3 */
+  SSL_CTX_set_options(self->ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
 
   amqp_set_socket(state, (amqp_socket_t *)self);
 

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -234,11 +234,11 @@ amqp_socket_open_noblock(amqp_socket_t *self, const char *host, int port, struct
 }
 
 int
-amqp_socket_close(amqp_socket_t *self)
+amqp_socket_close(amqp_socket_t *self, amqp_socket_close_enum force)
 {
   assert(self);
   assert(self->klass->close);
-  return self->klass->close(self);
+  return self->klass->close(self, force);
 }
 
 void
@@ -852,7 +852,7 @@ beginrecv:
 
     if (AMQP_STATUS_TIMEOUT == res) {
       if (amqp_time_equal(deadline, state->next_recv_heartbeat)) {
-        amqp_socket_close(state->socket);
+        amqp_socket_close(state->socket, AMQP_SC_FORCE);
         return AMQP_STATUS_HEARTBEAT_TIMEOUT;
       } else if (amqp_time_equal(deadline, timeout_deadline)) {
         return AMQP_STATUS_TIMEOUT;

--- a/librabbitmq/amqp_socket.h
+++ b/librabbitmq/amqp_socket.h
@@ -45,6 +45,11 @@ typedef enum {
   AMQP_SF_POLLERR = 8
 } amqp_socket_flag_enum;
 
+typedef enum {
+  AMQP_SC_NONE = 0,
+  AMQP_SC_FORCE = 1
+} amqp_socket_close_enum;
+
 int
 amqp_os_socket_error(void);
 
@@ -55,7 +60,7 @@ amqp_os_socket_close(int sockfd);
 typedef ssize_t (*amqp_socket_send_fn)(void *, const void *, size_t, int);
 typedef ssize_t (*amqp_socket_recv_fn)(void *, void *, size_t, int);
 typedef int (*amqp_socket_open_fn)(void *, const char *, int, struct timeval *);
-typedef int (*amqp_socket_close_fn)(void *);
+typedef int (*amqp_socket_close_fn)(void *, amqp_socket_close_enum);
 typedef int (*amqp_socket_get_sockfd_fn)(void *);
 typedef void (*amqp_socket_delete_fn)(void *);
 
@@ -132,11 +137,13 @@ amqp_socket_recv(amqp_socket_t *self, void *buf, size_t len, int flags);
  * longer be referenced.
  *
  * \param [in,out] self A socket object.
+ * \param [in] force, if set, just close the socket, don't attempt a TLS
+ * shutdown.
  *
  * \return Zero upon success, non-zero otherwise.
  */
 int
-amqp_socket_close(amqp_socket_t *self);
+amqp_socket_close(amqp_socket_t *self, amqp_socket_close_enum force);
 
 /**
  * Destroy a socket object

--- a/librabbitmq/amqp_ssl_socket.h
+++ b/librabbitmq/amqp_ssl_socket.h
@@ -168,6 +168,36 @@ void
 AMQP_CALL
 amqp_ssl_socket_set_verify_hostname(amqp_socket_t *self, amqp_boolean_t verify);
 
+typedef enum {
+  AMQP_TLSv1 = 1,
+  AMQP_TLSv1_1 = 2,
+  AMQP_TLSv1_2 = 3,
+  AMQP_TLSvLATEST = 0xFFFF
+} amqp_tls_version_t;
+
+/**
+ * Set min and max TLS versions.
+ *
+ * Set the oldest and newest acceptable TLS versions that are acceptable when
+ * connecting to the broker. Set min == max to restrict to just that
+ * version.
+ *
+ * \param [in,out] self An SSL/TLS socket object.
+ * \param [in] min the minimum acceptable TLS version
+ * \param [in] max the maxmium acceptable TLS version
+ * \returns AMQP_STATUS_OK on success, AMQP_STATUS_UNSUPPORTED if OpenSSL does
+ * not support the requested TLS version, AMQP_STATUS_INVALID_PARAMETER if an
+ * invalid combination of parameters is passed.
+ *
+ * \since v0.8.0
+ */
+AMQP_PUBLIC_FUNCTION
+int
+AMQP_CALL
+amqp_ssl_socket_set_ssl_versions(amqp_socket_t *self,
+                                 amqp_tls_version_t min,
+                                 amqp_tls_version_t max);
+
 /**
  * Sets whether rabbitmq-c initializes the underlying SSL library.
  *

--- a/librabbitmq/amqp_tcp_socket.c
+++ b/librabbitmq/amqp_tcp_socket.c
@@ -180,7 +180,7 @@ amqp_tcp_socket_open(void *base, const char *host, int port, struct timeval *tim
 }
 
 static int
-amqp_tcp_socket_close(void *base)
+amqp_tcp_socket_close(void *base, AMQP_UNUSED amqp_socket_close_enum force)
 {
   struct amqp_tcp_socket_t *self = (struct amqp_tcp_socket_t *)base;
   if (-1 == self->sockfd) {
@@ -208,7 +208,7 @@ amqp_tcp_socket_delete(void *base)
   struct amqp_tcp_socket_t *self = (struct amqp_tcp_socket_t *)base;
 
   if (self) {
-    amqp_tcp_socket_close(self);
+    amqp_tcp_socket_close(self, AMQP_SC_NONE);
     free(self);
   }
 }


### PR DESCRIPTION
Allow selection of desired TLS version when opening an SSL socket.

This also implicitly disables SSLv2, SSLv3.

Fixes #305

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/310)
<!-- Reviewable:end -->
