### PR TITLE
Lib: don't try hard when closing SSL sockets

### DIFF
--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -234,11 +234,11 @@ amqp_socket_open_noblock(amqp_socket_t *self, const char *host, int port, struct
 }
 
 int
-amqp_socket_close(amqp_socket_t *self)
+amqp_socket_close(amqp_socket_t *self, amqp_socket_close_enum force)
 {
   assert(self);
   assert(self->klass->close);
-  return self->klass->close(self);
+  return self->klass->close(self, force);
 }
 
 void
@@ -852,7 +852,7 @@ beginrecv:
 
     if (AMQP_STATUS_TIMEOUT == res) {
       if (amqp_time_equal(deadline, state->next_recv_heartbeat)) {
-        amqp_socket_close(state->socket);
+        amqp_socket_close(state->socket, AMQP_SC_FORCE);
         return AMQP_STATUS_HEARTBEAT_TIMEOUT;
       } else if (amqp_time_equal(deadline, timeout_deadline)) {
         return AMQP_STATUS_TIMEOUT;

--- a/librabbitmq/amqp_socket.h
+++ b/librabbitmq/amqp_socket.h
@@ -45,6 +45,11 @@ typedef enum {
   AMQP_SF_POLLERR = 8
 } amqp_socket_flag_enum;
 
+typedef enum {
+  AMQP_SC_NONE = 0,
+  AMQP_SC_FORCE = 1
+} amqp_socket_close_enum;
+
 int
 amqp_os_socket_error(void);
 
@@ -55,7 +60,7 @@ amqp_os_socket_close(int sockfd);
 typedef ssize_t (*amqp_socket_send_fn)(void *, const void *, size_t, int);
 typedef ssize_t (*amqp_socket_recv_fn)(void *, void *, size_t, int);
 typedef int (*amqp_socket_open_fn)(void *, const char *, int, struct timeval *);
-typedef int (*amqp_socket_close_fn)(void *);
+typedef int (*amqp_socket_close_fn)(void *, amqp_socket_close_enum);
 typedef int (*amqp_socket_get_sockfd_fn)(void *);
 typedef void (*amqp_socket_delete_fn)(void *);
 
@@ -132,11 +137,13 @@ amqp_socket_recv(amqp_socket_t *self, void *buf, size_t len, int flags);
  * longer be referenced.
  *
  * \param [in,out] self A socket object.
+ * \param [in] force, if set, just close the socket, don't attempt a TLS
+ * shutdown.
  *
  * \return Zero upon success, non-zero otherwise.
  */
 int
-amqp_socket_close(amqp_socket_t *self);
+amqp_socket_close(amqp_socket_t *self, amqp_socket_close_enum force);
 
 /**
  * Destroy a socket object

--- a/librabbitmq/amqp_tcp_socket.c
+++ b/librabbitmq/amqp_tcp_socket.c
@@ -180,7 +180,7 @@ amqp_tcp_socket_open(void *base, const char *host, int port, struct timeval *tim
 }
 
 static int
-amqp_tcp_socket_close(void *base)
+amqp_tcp_socket_close(void *base, AMQP_UNUSED amqp_socket_close_enum force)
 {
   struct amqp_tcp_socket_t *self = (struct amqp_tcp_socket_t *)base;
   if (-1 == self->sockfd) {
@@ -208,7 +208,7 @@ amqp_tcp_socket_delete(void *base)
   struct amqp_tcp_socket_t *self = (struct amqp_tcp_socket_t *)base;
 
   if (self) {
-    amqp_tcp_socket_close(self);
+    amqp_tcp_socket_close(self, AMQP_SC_NONE);
     free(self);
   }
 }


### PR DESCRIPTION
If a heartbeat timeout occurs skip calling SSL_shutdown as it involves doing a
send() which will likely hang. Additionally don't wait for a response when doing
an SSL_shutdown, as the underlying transport will not be reused.

Fixes #313

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/316)
<!-- Reviewable:end -->
