### PR TITLE
Fix for commit ba7c342a55e200d1f72b30d74df1591b0f72de49

### DIFF
--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -313,7 +313,7 @@ start_poll:
 #ifndef _WIN32
   /* On Win32 connect() failure is indicated through the exceptfds, it does not
    * make any sense to allow POLLERR on any other platform or condition */
-  assert(0 == event & AMQP_SF_POLLERR);
+  assert(0 == (event & AMQP_SF_POLLERR));
 #endif
 
 start_select:


### PR DESCRIPTION
This commit makes assert condition always false (forgotten parenthesis)

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/317)
<!-- Reviewable:end -->
