### PR TITLE
Lib: amqp_parse_url should initialize output

### DIFF
--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -2306,6 +2306,10 @@ AMQP_CALL amqp_default_connection_info(struct amqp_connection_info *parsed);
  *  amqp://guest:guest\@localhost:5672//
  *  amqp://guest:guest\@localhost/myvhost
  *
+ *  Any missing parts of the URL will be set to the defaults specified in
+ *  amqp_default_connection_info. For amqps: URLs the default port will be set
+ *  to 5671 instead of 5672 for non-SSL URLs.
+ *
  * \note This function modifies url parameter.
  *
  * \param [in] url URI to parse, note that this parameter is modified by the

--- a/librabbitmq/amqp_url.c
+++ b/librabbitmq/amqp_url.c
@@ -120,6 +120,8 @@ int amqp_parse_url(char *url, struct amqp_connection_info *parsed)
   char *host;
   char *port = NULL;
 
+  amqp_default_connection_info(parsed);
+
   /* check the prefix */
   if (!strncmp(url, "amqp://", 7)) {
     /* do nothing */

--- a/tests/test_parse_url.c
+++ b/tests/test_parse_url.c
@@ -78,7 +78,6 @@ static void parse_success(const char *url,
   struct amqp_connection_info ci;
   int res;
 
-  amqp_default_connection_info(&ci);
   res = amqp_parse_url(s, &ci);
   if (res) {
     fprintf(stderr,


### PR DESCRIPTION
amqp_parse_url() calls amqp_default_connection_info() to initialize the output
parameter to sensible defaults that mirror what the Java and .NET do.

Fixes #319

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/320)
<!-- Reviewable:end -->
