### PR TITLE
build: Add check for posix_spawn functions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -144,7 +144,8 @@ endif()
 cmake_pop_check_state()
 
 check_library_exists(rt clock_gettime "time.h" CLOCK_GETTIME_NEEDS_LIBRT)
-if (CLOCK_GETTIME_NEEDS_LIBRT)
+check_library_exists(rt posix_spawnp "spawn.h" POSIX_SPAWNP_NEEDS_LIBRT)
+if (CLOCK_GETTIME_NEEDS_LIBRT OR POSIX_SPAWNP_NEEDS_LIBRT)
   set(LIBRT rt)
 endif()
 

--- a/configure.ac
+++ b/configure.ac
@@ -102,6 +102,7 @@ AC_SEARCH_LIBS([socket], [socket], [],
                              [AC_MSG_ERROR([cannot find socket library (library with socket symbol)])],
                              [-lnsl])])
 AC_SEARCH_LIBS([clock_gettime], [rt])
+AC_SEARCH_LIBS([posix_spawnp], [rt])
 AC_MSG_CHECKING([if htonll is defined])
 
 dnl # Check for htonll


### PR DESCRIPTION
These are usually found in librt. On some systems clock_gettime is also
in librt so checking for it was implicitly satisfying the requirement
for the posix_spawn functions. On newer systems (glibc >2.17 for
example) clock_gettime is also found in libc so AC_SEARCH_LIBS() decides
that it is not necessary to add -lrt to LIBS.

Add an explicit check for posix_spawnp() to decide if -lrt is necessary.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/322)
<!-- Reviewable:end -->
