### PR TITLE
Lib: use amqp_hostcheck correctly

### DIFF
--- a/librabbitmq/amqp_openssl_hostname_validation.c
+++ b/librabbitmq/amqp_openssl_hostname_validation.c
@@ -79,7 +79,7 @@ static amqp_hostname_validation_result amqp_matches_common_name(
   }
 
   // Compare expected hostname with the CN
-  if (strcasecmp(hostname, common_name_str) == 0) {
+  if (amqp_hostcheck(common_name_str, hostname) == AMQP_HCR_MATCH) {
     return AMQP_HVR_MATCH_FOUND;
   } else {
     return AMQP_HVR_MATCH_NOT_FOUND;
@@ -126,7 +126,7 @@ static amqp_hostname_validation_result amqp_matches_subject_alternative_name(
         result = AMQP_HVR_MALFORMED_CERTIFICATE;
         break;
       } else {  // Compare expected hostname with the DNS name
-        if (amqp_hostcheck(hostname, dns_name) == 0) {
+        if (amqp_hostcheck(dns_name, hostname) == AMQP_HCR_MATCH) {
           result = AMQP_HVR_MATCH_FOUND;
           break;
         }


### PR DESCRIPTION
Use amqp_hostcheck instead of strcasecmp, and pass in the correct arguments in
the right order in both SAN and CN codepaths.

Fixes #326

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/327)
<!-- Reviewable:end -->
