### PR TITLE
Lib: correctly check SSL connection

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -183,6 +183,7 @@ amqp_ssl_socket_open(void *base, const char *host, int port, struct timeval *tim
   long result;
   int status;
   amqp_time_t deadline;
+  X509 *cert;
   if (-1 != self->sockfd) {
     return AMQP_STATUS_SOCKET_INUSE;
   }
@@ -236,12 +237,14 @@ start_connect:
   }
 
   if (self->verify_peer) {
+    cert = SSL_get_peer_certificate(self->ssl);
     result = SSL_get_verify_result(self->ssl);
-    if (X509_V_OK != result) {
+    if (!cert || X509_V_OK != result) {
       self->internal_error = result;
       status = AMQP_STATUS_SSL_PEER_VERIFY_FAILED;
       goto error_out3;
     }
+    X509_free(cert);
   }
   if (self->verify_hostname) {
     int verify_status = amqp_ssl_socket_verify_hostname(self, host);

--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -238,13 +238,20 @@ start_connect:
 
   if (self->verify_peer) {
     cert = SSL_get_peer_certificate(self->ssl);
+    if (!cert) {
+      self->internal_error = 0;
+      status = AMQP_STATUS_SSL_PEER_VERIFY_FAILED;
+      goto error_out3;
+    }
+
+    X509_free(cert);
+
     result = SSL_get_verify_result(self->ssl);
-    if (!cert || X509_V_OK != result) {
+    if (X509_V_OK != result) {
       self->internal_error = result;
       status = AMQP_STATUS_SSL_PEER_VERIFY_FAILED;
       goto error_out3;
     }
-    X509_free(cert);
   }
   if (self->verify_hostname) {
     int verify_status = amqp_ssl_socket_verify_hostname(self, host);

--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -183,7 +183,6 @@ amqp_ssl_socket_open(void *base, const char *host, int port, struct timeval *tim
   long result;
   int status;
   amqp_time_t deadline;
-  X509 *cert;
   if (-1 != self->sockfd) {
     return AMQP_STATUS_SOCKET_INUSE;
   }
@@ -237,6 +236,7 @@ start_connect:
   }
 
   if (self->verify_peer) {
+    X509 *cert;
     cert = SSL_get_peer_certificate(self->ssl);
     if (!cert) {
       self->internal_error = 0;


### PR DESCRIPTION
According to "https://www.openssl.org/docs/manmaster/ssl/SSL_get_verify_result.html",
to verify SSL connection result, SSL_get_verify_result() needs to be
called with SSL_get_peer_certificate(). In default mode, which
verify_peer and verify_hostname are activated, then there is no problem
because in verify_hostname, the existence of certificate is confirmed.
However, it is possible that the user want to verify_peer,
but not verify_host. In such case, it is not working as they wanted.
Because with invalid certificate, the attacker can bypass certificate validity check.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/329)
<!-- Reviewable:end -->
