### PR TITLE
Fix hostname verification: amqp_openssl.c

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -245,7 +245,7 @@ start_connect:
   }
   if (self->verify_hostname) {
     int verify_status = amqp_ssl_socket_verify_hostname(self, host);
-    if (verify_status) {
+    if (!verify_status) {
       self->internal_error = 0;
       status = AMQP_STATUS_SSL_HOSTNAME_VERIFY_FAILED;
       goto error_out3;


### PR DESCRIPTION
It seems that the hostname verification in amqp_ssl_socket_open(...) results in just the opposite of the desired behavior.
I suggest a simple fix.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/332)
<!-- Reviewable:end -->
