### PR TITLE
Adding build/ in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 /aclocal.m4
 /autom4te.cache
 /bin*
+/build
 /compile
 /config.guess
 /config.h


### PR DESCRIPTION
Default build instructions asks to mdkir build, so it makes
sense to also include it in .gitignore file.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/333)
<!-- Reviewable:end -->
