### PR TITLE
Lib: don't use TCP_NOPUSH under cygwin

### DIFF
--- a/librabbitmq/amqp_tcp_socket.c
+++ b/librabbitmq/amqp_tcp_socket.c
@@ -69,7 +69,9 @@ amqp_tcp_socket_send(void *base, const void *buf, size_t len, int flags)
   if (flags & AMQP_SF_MORE) {
     flagz |= MSG_MORE;
   }
-#elif defined(TCP_NOPUSH)
+  /* Cygwin defines TCP_NOPUSH, but trying to use it will return not
+   * implemented. Disable it here. */
+#elif defined(TCP_NOPUSH) && !defined(__CYGWIN__)
   if (flags & AMQP_SF_MORE && !(self->state & AMQP_SF_MORE)) {
     int one = 1;
     res = setsockopt(self->sockfd, IPPROTO_TCP, TCP_NOPUSH, &one, sizeof(one));


### PR DESCRIPTION
Cygwin defines TCP_NOPUSH, but fails with an error when you try to use
it. Disable it on Cygwin.

Fixes #335

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/336)
<!-- Reviewable:end -->
