### PR TITLE
Examples: add flags to enable SSL verification.

### DIFF
--- a/examples/amqps_consumer.c
+++ b/examples/amqps_consumer.c
@@ -159,7 +159,7 @@ int main(int argc, char const *const *argv)
 
   if (argc < 3) {
     fprintf(stderr, "Usage: amqps_consumer host port "
-            "[cacert.pem [key.pem cert.pem]]\n");
+            "[cacert.pem [verifypeer] [verifyhostname] [key.pem cert.pem]]\n");
     return 1;
   }
 
@@ -175,17 +175,29 @@ int main(int argc, char const *const *argv)
     die("creating SSL/TLS socket");
   }
 
+  amqp_ssl_socket_set_verify_peer(socket, 0);
+  amqp_ssl_socket_set_verify_hostname(socket, 0);
+
   if (argc > 3) {
+    int nextarg = 4;
     status = amqp_ssl_socket_set_cacert(socket, argv[3]);
     if (status) {
       die("setting CA certificate");
     }
-  }
-
-  if (argc > 5) {
-    status = amqp_ssl_socket_set_key(socket, argv[5], argv[4]);
-    if (status) {
-      die("setting client key");
+    if (argc > nextarg && !strcmp("verifypeer", argv[nextarg])) {
+      amqp_ssl_socket_set_verify_peer(socket, 1);
+      nextarg++;
+    }
+    if (argc > nextarg && !strcmp("verifyhostname", argv[nextarg])) {
+      amqp_ssl_socket_set_verify_hostname(socket, 1);
+      nextarg++;
+    }
+    if (argc > nextarg + 1) {
+      status =
+          amqp_ssl_socket_set_key(socket, argv[nextarg + 1], argv[nextarg]);
+      if (status) {
+        die("setting client key");
+      }
     }
   }
 

--- a/examples/amqps_exchange_declare.c
+++ b/examples/amqps_exchange_declare.c
@@ -58,7 +58,8 @@ int main(int argc, char const *const *argv)
 
   if (argc < 5) {
     fprintf(stderr, "Usage: amqps_exchange_declare host port exchange "
-            "exchangetype [cacert.pem [key.pem cert.pem]]\n");
+            "exchangetype [cacert.pem [verifypeer] [verifyhostname] "
+            "[key.pem cert.pem]]\n");
     return 1;
   }
 
@@ -74,17 +75,29 @@ int main(int argc, char const *const *argv)
     die("creating SSL/TLS socket");
   }
 
+  amqp_ssl_socket_set_verify_peer(socket, 0);
+  amqp_ssl_socket_set_verify_hostname(socket, 0);
+
   if (argc > 5) {
+    int nextarg = 6;
     status = amqp_ssl_socket_set_cacert(socket, argv[5]);
     if (status) {
       die("setting CA certificate");
     }
-  }
-
-  if (argc > 7) {
-    status = amqp_ssl_socket_set_key(socket, argv[7], argv[6]);
-    if (status) {
-      die("setting client key/cert");
+    if (argc > nextarg && !strcmp("verifypeer", argv[nextarg])) {
+      amqp_ssl_socket_set_verify_peer(socket, 1);
+      nextarg++;
+    }
+    if (argc > nextarg && !strcmp("verifyhostname", argv[nextarg])) {
+      amqp_ssl_socket_set_verify_hostname(socket, 1);
+      nextarg++;
+    }
+    if (argc > nextarg + 1) {
+      status =
+          amqp_ssl_socket_set_key(socket, argv[nextarg + 1], argv[nextarg]);
+      if (status) {
+        die("setting client key/cert");
+      }
     }
   }
 

--- a/examples/amqps_listen.c
+++ b/examples/amqps_listen.c
@@ -62,7 +62,7 @@ int main(int argc, char const *const *argv)
 
   if (argc < 5) {
     fprintf(stderr, "Usage: amqps_listen host port exchange bindingkey "
-            "[cacert.pem [key.pem cert.pem]]\n");
+            "[cacert.pem [verifypeer] [verifyhostname] [key.pem cert.pem]]\n");
     return 1;
   }
 
@@ -78,19 +78,32 @@ int main(int argc, char const *const *argv)
     die("creating SSL/TLS socket");
   }
 
+  amqp_ssl_socket_set_verify_peer(socket, 0);
+  amqp_ssl_socket_set_verify_hostname(socket, 0);
+
   if (argc > 5) {
+    int nextarg = 6;
     status = amqp_ssl_socket_set_cacert(socket, argv[5]);
     if (status) {
       die("setting CA certificate");
     }
-  }
-
-  if (argc > 7) {
-    status = amqp_ssl_socket_set_key(socket, argv[7], argv[6]);
-    if (status) {
-      die("setting client cert");
+    if (argc > nextarg && !strcmp("verifypeer", argv[nextarg])) {
+      amqp_ssl_socket_set_verify_peer(socket, 1);
+      nextarg++;
+    }
+    if (argc > nextarg && !strcmp("verifyhostname", argv[nextarg])) {
+      amqp_ssl_socket_set_verify_hostname(socket, 1);
+      nextarg++;
+    }
+    if (argc > nextarg + 1) {
+      status =
+          amqp_ssl_socket_set_key(socket, argv[nextarg + 1], argv[nextarg]);
+      if (status) {
+        die("setting client cert");
+      }
     }
   }
+
 
   status = amqp_socket_open(socket, hostname, port);
   if (status) {

--- a/examples/amqps_producer.c
+++ b/examples/amqps_producer.c
@@ -122,7 +122,7 @@ int main(int argc, char const *const *argv)
 
   if (argc < 5) {
     fprintf(stderr, "Usage: amqps_producer host port rate_limit message_count "
-            "[cacert.pem [key.pem cert.pem]]\n");
+            "[cacert.pem [verifypeer] [verifyhostname] [key.pem cert.pem]]\n");
     return 1;
   }
 
@@ -138,17 +138,29 @@ int main(int argc, char const *const *argv)
     die("creating SSL/TLS socket");
   }
 
+  amqp_ssl_socket_set_verify_peer(socket, 0);
+  amqp_ssl_socket_set_verify_hostname(socket, 0);
+
   if (argc > 5) {
+    int nextarg = 6;
     status = amqp_ssl_socket_set_cacert(socket, argv[5]);
     if (status) {
       die("setting CA certificate");
     }
-  }
-
-  if (argc > 7) {
-    status = amqp_ssl_socket_set_key(socket, argv[7], argv[6]);
-    if (status) {
-      die("setting client cert");
+    if (argc > nextarg && !strcmp("verifypeer", argv[nextarg])) {
+      amqp_ssl_socket_set_verify_peer(socket, 1);
+      nextarg++;
+    }
+    if (argc > nextarg && !strcmp("verifyhostname", argv[nextarg])) {
+      amqp_ssl_socket_set_verify_hostname(socket, 1);
+      nextarg++;
+    }
+    if (argc > nextarg + 1) {
+      status =
+          amqp_ssl_socket_set_key(socket, argv[nextarg + 1], argv[nextarg]);
+      if (status) {
+        die("setting client cert");
+      }
     }
   }
 

--- a/examples/amqps_sendstring.c
+++ b/examples/amqps_sendstring.c
@@ -59,7 +59,8 @@ int main(int argc, char const *const *argv)
 
   if (argc < 6) {
     fprintf(stderr, "Usage: amqps_sendstring host port exchange routingkey "
-            "messagebody [cacert.pem [key.pem cert.pem]]\n");
+            "messagebody [cacert.pem [verifypeer] [verifyhostname] "
+            "[key.pem cert.pem]]\n");
     return 1;
   }
 
@@ -76,17 +77,29 @@ int main(int argc, char const *const *argv)
     die("creating SSL/TLS socket");
   }
 
+  amqp_ssl_socket_set_verify_peer(socket, 0);
+  amqp_ssl_socket_set_verify_hostname(socket, 0);
+
   if (argc > 6) {
+    int nextarg = 7;
     status = amqp_ssl_socket_set_cacert(socket, argv[6]);
     if (status) {
       die("setting CA certificate");
     }
-  }
-
-  if (argc > 8) {
-    status = amqp_ssl_socket_set_key(socket, argv[8], argv[7]);
-    if (status) {
-      die("setting client cert");
+    if (argc > nextarg && !strcmp("verifypeer", argv[nextarg])) {
+      amqp_ssl_socket_set_verify_peer(socket, 1);
+      nextarg++;
+    }
+    if (argc > nextarg && !strcmp("verifyhostname", argv[nextarg])) {
+      amqp_ssl_socket_set_verify_hostname(socket, 1);
+      nextarg++;
+    }
+    if (argc > nextarg + 1) {
+      status =
+          amqp_ssl_socket_set_key(socket, argv[nextarg + 1], argv[nextarg]);
+      if (status) {
+        die("setting client cert");
+      }
     }
   }
 

--- a/examples/amqps_unbind.c
+++ b/examples/amqps_unbind.c
@@ -59,7 +59,7 @@ int main(int argc, char const *const *argv)
 
   if (argc < 6) {
     fprintf(stderr, "Usage: amqps_unbind host port exchange bindingkey queue "
-            "[cacert.pem [key.pem cert.pem]]\n");
+            "[cacert.pem [verifypeer] [verifyhostname] [key.pem cert.pem]]\n");
     return 1;
   }
 
@@ -76,17 +76,29 @@ int main(int argc, char const *const *argv)
     die("creating SSL/TLS socket");
   }
 
+  amqp_ssl_socket_set_verify_peer(socket, 0);
+  amqp_ssl_socket_set_verify_hostname(socket, 0);
+
   if (argc > 6) {
+    int nextarg = 7;
     status = amqp_ssl_socket_set_cacert(socket, argv[6]);
     if (status) {
       die("setting CA certificate");
     }
-  }
-
-  if (argc > 8) {
-    status = amqp_ssl_socket_set_key(socket, argv[8], argv[7]);
-    if (status) {
-      die("setting client cert");
+    if (argc > nextarg && !strcmp("verifypeer", argv[nextarg])) {
+      amqp_ssl_socket_set_verify_peer(socket, 1);
+      nextarg++;
+    }
+    if (argc > nextarg && !strcmp("verifyhostname", argv[nextarg])) {
+      amqp_ssl_socket_set_verify_hostname(socket, 1);
+      nextarg++;
+    }
+    if (argc > nextarg + 1) {
+      status =
+          amqp_ssl_socket_set_key(socket, argv[nextarg + 1], argv[nextarg]);
+      if (status) {
+        die("setting client cert");
+      }
     }
   }
 


### PR DESCRIPTION
Add verifypeer flag to enable verification of broker's certificate, and
verifyhostname flag to enable verification of broker's hostname.

Fixes #194

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/342)
<!-- Reviewable:end -->
