### PR TITLE
Enable the MSVC /analyzer on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,7 +30,7 @@ install:
       & "$dir\$file" /silent /verysilent /sp- /suppressmsgboxes /dir="c:\OpenSSL"
 
 before_build:
-  - cmake -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_TESTS=ON -DENABLE_SSL_SUPPORT=True -G"%GENERATOR%" .
+  - cmake -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_TESTS=ON -DENABLE_SSL_SUPPORT=True -DCMAKE_C_FLAGS="/analyze" -G"%GENERATOR%" .
 
 build:
   project: ALL_BUILD.vcxproj

--- a/librabbitmq/amqp_consumer.c
+++ b/librabbitmq/amqp_consumer.c
@@ -34,6 +34,10 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _MSC_VER
+# pragma warning( disable: 4100 )  /* unreferenced formal parameter */
+#endif
+
 static
 int amqp_basic_properties_clone(amqp_basic_properties_t *original,
                                 amqp_basic_properties_t *clone,

--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -45,6 +45,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef _MSC_VER
+# pragma warning( disable: 4100 )  /* unreferenced formal parameter */
+#endif
 
 static int initialize_openssl(void);
 static int destroy_openssl(void);

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -318,11 +318,20 @@ start_poll:
 
 start_select:
   FD_ZERO(&fds);
+#ifdef _WIN32
+  FD_SET((SOCKET)fd, &fds);
+#else
   FD_SET(fd, &fds);
+#endif
+
 
   if (event & AMQP_SF_POLLERR) {
     FD_ZERO(&exceptfds);
+#ifdef _WIN32
+    FD_SET((SOCKET)fd, &exceptfds);
+#else
     FD_SET(fd, &exceptfds);
+#endif
     exceptfdsp = &exceptfds;
   } else {
     exceptfdsp = NULL;

--- a/librabbitmq/amqp_tcp_socket.c
+++ b/librabbitmq/amqp_tcp_socket.c
@@ -42,6 +42,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#ifdef _MSC_VER
+# pragma warning( disable: 4100 )  /* unreferenced formal parameter */
+#endif
+
 struct amqp_tcp_socket_t {
   const struct amqp_socket_class_t *klass;
   int sockfd;

--- a/librabbitmq/win32/threads.c
+++ b/librabbitmq/win32/threads.c
@@ -25,6 +25,10 @@
 
 #include <stdlib.h>
 
+#ifdef _MSC_VER
+# pragma warning( disable: 4100 )  /* unreferenced formal parameter */
+#endif
+
 DWORD
 pthread_self(void)
 {


### PR DESCRIPTION
Enable the MSVC analyzer on appveyor and squash warnings that are brought up by the analyzer.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/345)

<!-- Reviewable:end -->
