### PR TITLE
Fix duplicate WIN32_LEAN_AND_MEAN definition

### DIFF
--- a/librabbitmq/amqp_time.c
+++ b/librabbitmq/amqp_time.c
@@ -37,7 +37,9 @@
 
 
 #ifdef AMQP_WIN_TIMER_API
-#define WIN32_LEAN_AND_MEAN
+#ifndef WIN32_LEAN_AND_MEAN
+# define WIN32_LEAN_AND_MEAN
+#endif
 #include <Windows.h>
 
 uint64_t


### PR DESCRIPTION
Fix MSVC C4005 warning in amqp_time.c.

`rabbitmq-c\librabbitmq\amqp_time.c(40): warning C4005: 'WIN32_LEAN_AND_MEAN': macro redefinition`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/351)
<!-- Reviewable:end -->
