### PR TITLE
Add NORETURN macro for MSVC

### DIFF
--- a/librabbitmq/amqp_private.h
+++ b/librabbitmq/amqp_private.h
@@ -69,6 +69,10 @@
   __attribute__ ((__noreturn__))
 #define AMQP_UNUSED \
   __attribute__ ((__unused__))
+#elif defined(_MSC_VER)
+#define AMQP_NORETURN \
+  __declspec(noreturn)
+#define AMQP_UNUSED
 #else
 #define AMQP_NORETURN
 #define AMQP_UNUSED


### PR DESCRIPTION
Fix MSVC C4715 warning (level 1):

```
rabbitmq-c\librabbitmq\amqp_connection.c(410): warning C4715: 'amqp_handle_input': not all control paths return a value
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/352)
<!-- Reviewable:end -->
