### PR TITLE
Fixes warning about not all code paths returning a value

### DIFF
--- a/librabbitmq/amqp_connection.c
+++ b/librabbitmq/amqp_connection.c
@@ -406,6 +406,7 @@ int amqp_handle_input(amqp_connection_state_t state,
   default:
     amqp_abort("Internal error: invalid amqp_connection_state_t->state %d",
                state->state);
+    return (int)AMQP_STATUS_UNEXPECTED_STATE;
   }
 }
 


### PR DESCRIPTION
Return unexpected state value. Warning is raised in VS2015

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/359)
<!-- Reviewable:end -->
