### PR TITLE
linking with static OpenSSL requires CRYPT32.LIB

### DIFF
--- a/librabbitmq/CMakeLists.txt
+++ b/librabbitmq/CMakeLists.txt
@@ -93,6 +93,9 @@ if (ENABLE_SSL_SUPPORT)
     # Apple has deprecated OpenSSL in 10.7+. This disables that warning.
     set_source_files_properties(${AMQP_SSL_SRCS}
       PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
+  elseif (WIN32)
+    # linking with static OpenSSL requires CRYPT32.LIB https://git.openssl.org/?p=openssl.git;a=blob;f=NOTES.WIN
+    list(APPEND AMQP_SSL_LIBS "crypt32")
   endif()
 
   if (ENABLE_THREAD_SAFETY)


### PR DESCRIPTION
rabbitmq-c fails to build from source when linking with a static openssl library using the MSVC compiler, see also https://git.openssl.org/?p=openssl.git;a=blob;f=NOTES.WIN

```
"...\rabbitmq-c\build\ALL_BUILD.vcxproj" (default target) (1) ->
"...\rabbitmq-c\build\examples\amqp_bind.vcxproj" (default target) (3) ->
"...\rabbitmq-c\build\librabbitmq\rabbitmq.vcxproj" (default target) (4) ->
(Link target) ->
  libeay32.lib(e_capi.obj) : error LNK2019: unresolved external symbol __imp_CertOpenStore referenced in function capi_open_store [...\rabbitmq-c\build\librabbitmq\rabbitmq.vcxproj]
  libeay32.lib(e_capi.obj) : error LNK2019: unresolved external symbol __imp_CertCloseStore referenced in function capi_find_key [...\rabbitmq-c\build\librabbitmq\rabbitmq.vcxproj]
  libeay32.lib(e_capi.obj) : error LNK2019: unresolved external symbol __imp_CertEnumCertificatesInStore referenced in function capi_find_cert [...\rabbitmq-c\build\librabbitmq\rabbitmq.vcxproj]
  libeay32.lib(e_capi.obj) : error LNK2019: unresolved external symbol __imp_CertFindCertificateInStore referenced in function capi_find_cert [...\rabbitmq-c\build\librabbitmq\rabbitmq.vcxproj]
  libeay32.lib(e_capi.obj) : error LNK2019: unresolved external symbol __imp_CertDuplicateCertificateContext referenced in function capi_load_ssl_client_cert [...\rabbitmq-c\build\librabbitmq\rabbitmq.vcxproj]
  libeay32.lib(e_capi.obj) : error LNK2019: unresolved external symbol __imp_CertFreeCertificateContext referenced in function capi_rsa_free [...\rabbitmq-c\build\librabbitmq\rabbitmq.vcxproj]
  libeay32.lib(e_capi.obj) : error LNK2019: unresolved external symbol __imp_CertGetCertificateContextProperty referenced in function capi_cert_get_fname [...\rabbitmq-c\build\librabbitmq\rabbitmq.vcxproj]
  ...\rabbitmq-c\build\librabbitmq\Release\rabbitmq.4.dll : fatal error LNK1120: 7 unresolved externals [...\rabbitmq-c\build\librabbitmq\rabbitmq.vcxproj]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/371)
<!-- Reviewable:end -->
