### PR TITLE
removed /Z7 key when using non-Microsoft compiler

### DIFF
--- a/librabbitmq/CMakeLists.txt
+++ b/librabbitmq/CMakeLists.txt
@@ -147,11 +147,16 @@ if (BUILD_STATIC_LIBS)
     set_target_properties(rabbitmq-static PROPERTIES COMPILE_DEFINITIONS AMQP_STATIC)
     if (WIN32)
         set_target_properties(rabbitmq-static PROPERTIES
-          # Embed debugging info in the library itself instead of generating
-          # a .pdb file.
-          COMPILE_OPTIONS "/Z7"
           VERSION ${RMQ_VERSION}
           OUTPUT_NAME librabbitmq.${RMQ_SOVERSION})
+		
+		if(MSVC)
+			set_target_properties(rabbitmq-static PROPERTIES
+			# Embed debugging info in the library itself instead of generating
+			# a .pdb file.
+			COMPILE_OPTIONS "/Z7")
+		endif(MSVC)
+		
     else (WIN32)
         set_target_properties(rabbitmq-static PROPERTIES VERSION ${RMQ_VERSION} SOVERSION ${RMQ_SOVERSION} OUTPUT_NAME rabbitmq)
     endif (WIN32)

--- a/librabbitmq/CMakeLists.txt
+++ b/librabbitmq/CMakeLists.txt
@@ -149,14 +149,14 @@ if (BUILD_STATIC_LIBS)
         set_target_properties(rabbitmq-static PROPERTIES
           VERSION ${RMQ_VERSION}
           OUTPUT_NAME librabbitmq.${RMQ_SOVERSION})
-		
-		if(MSVC)
-			set_target_properties(rabbitmq-static PROPERTIES
-			# Embed debugging info in the library itself instead of generating
-			# a .pdb file.
-			COMPILE_OPTIONS "/Z7")
-		endif(MSVC)
-		
+        
+        if(MSVC)
+            set_target_properties(rabbitmq-static PROPERTIES
+            # Embed debugging info in the library itself instead of generating
+            # a .pdb file.
+            COMPILE_OPTIONS "/Z7")
+        endif(MSVC)
+        
     else (WIN32)
         set_target_properties(rabbitmq-static PROPERTIES VERSION ${RMQ_VERSION} SOVERSION ${RMQ_SOVERSION} OUTPUT_NAME rabbitmq)
     endif (WIN32)


### PR DESCRIPTION
When using MinGW under Windows CMAKE generates **/Z7** key, which is treated as path by gcc compiler. This causes error *gcc.exe: /Z7 path or file not found*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/373)
<!-- Reviewable:end -->
