### PR TITLE
add noblock amqp_login_with_properties_noblock

### DIFF
--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -756,8 +756,8 @@ typedef enum amqp_status_enum_
  * \since v0.5
  */
 typedef enum {
-	AMQP_DELIVERY_NONPERSISTENT = 1, /**< Non-persistent message */
-	AMQP_DELIVERY_PERSISTENT = 2 /**< Persistent message */
+    AMQP_DELIVERY_NONPERSISTENT = 1, /**< Non-persistent message */
+    AMQP_DELIVERY_PERSISTENT = 2 /**< Persistent message */
 } amqp_delivery_mode_enum;
 
 AMQP_END_DECLS
@@ -1875,14 +1875,15 @@ AMQP_CALL amqp_login_with_properties(amqp_connection_state_t state, char const *
  * \param [in] state the connection object
  * \param [in] vhost the virtual host to connect to on the broker. The default
  *              on most brokers is "/"
- * \param [in] channel_max the limit for the number of channels for the connection.
- *             0 means no limit, and is a good default (AMQP_DEFAULT_MAX_CHANNELS)
- *             Note that the maximum number of channels the protocol supports
- *             is 65535 (2^16, with the 0-channel reserved)
+ * \param [in] channel_max the limit for the number of channels for the
+ *             connection. 0 means no limit, and is a good default
+ *             (AMQP_DEFAULT_MAX_CHANNELS). Note that the maximum number of
+ *             channels the protocol supports is 65535 (2^16, with the
+ *             0-channel reserved)
  * \param [in] frame_max the maximum size of an AMQP frame ont he wire to
- *              request of the broker for this connection. 4096 is the minimum
- *              size, 2^31-1 is the maximum, a good default is 131072 (128KB), or
- *              AMQP_DEFAULT_FRAME_SIZE
+ *             request of the broker for this connection. 4096 is the minimum
+ *             size, 2^31-1 is the maximum, a good default is 131072 (128KB),
+ *             or AMQP_DEFAULT_FRAME_SIZE
  * \param [in] heartbeat the number of seconds between heartbeat frame to
  *             request of the broker. A value of 0 disables heartbeats.
  *             Note rabbitmq-c only has partial support for hearts, as of

--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -2441,30 +2441,36 @@ amqp_table_t *
 amqp_get_client_properties(amqp_connection_state_t state);
 
 /**
- * Get the current value of the handshake timeout.
+ * Get the current value of the login handshake timeout.
+ * This tunes the timeout for completing the amqp_login and 
+ * amqp_login_with_properties functions. By default the timeout is 20 seconds.
+ * Note that by default the RabbitMQ broker has a 10 second timeout for
+ * completing the login handshake.
  *
  * \param [in] state the connection object
  * \return a pointer to a struct timeval containing the current value of the
- * handshake timeout set for current state. Return NULL if current timeout is
- * set to the infinite value.
+ * login handshake timeout set for current state. Return NULL if current timeout is
+ * set to the infinite value. The timeout is owned by the connection object.
  *
- * \since v0.8.2
+ * \since v0.9.0
  */
 AMQP_PUBLIC_FUNCTION
 struct timeval *
 AMQP_CALL amqp_get_handshake_timeout(amqp_connection_state_t state);
 
 /**
- * Set the new value for the handshake timeout.
+ * Set the new value for the login handshake timeout.
  *
  * \param [in] state the connection object
  * \param [in] timeout a pointer to a struct timeval containing value of the
- * handshake timeout that has to be set for current state. By default timeout
- * is pointed to the static struct timeval initialized with 20000 ms.
- * Initialize timeout == NULL to set infinite handshake timeout.
+ * login handshake timeout that has to be set for current state. 
+ * The passed timeout is copied by the function so it can be deleted
+ * immediately after the function call.
+ * By default the value of the timeout is set to 20000 ms.
+ * To set infinite handshake timeout just pass NULL value for the timeout.
  * \return AMQP_STATUS_OK.
  *
- * \since v0.8.2
+ * \since v0.9.0
  */
 AMQP_PUBLIC_FUNCTION
 int

--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -1865,74 +1865,6 @@ AMQP_CALL amqp_login_with_properties(amqp_connection_state_t state, char const *
                                      int channel_max, int frame_max, int heartbeat,
                                      const amqp_table_t *properties, amqp_sasl_method_enum sasl_method, ...);
 
-/**
- * Login to the broker passing a properties table with a timeout
- *
- * This function is similar to amqp_login() and differs in that it provides a
- * way to pass client properties to the broker. This is commonly used to
- * negotiate newer protocol features as they are supported by the broker.
- *
- * \param [in] state the connection object
- * \param [in] vhost the virtual host to connect to on the broker. The default
- *              on most brokers is "/"
- * \param [in] channel_max the limit for the number of channels for the
- *             connection. 0 means no limit, and is a good default
- *             (AMQP_DEFAULT_MAX_CHANNELS). Note that the maximum number of
- *             channels the protocol supports is 65535 (2^16, with the
- *             0-channel reserved)
- * \param [in] frame_max the maximum size of an AMQP frame ont he wire to
- *             request of the broker for this connection. 4096 is the minimum
- *             size, 2^31-1 is the maximum, a good default is 131072 (128KB),
- *             or AMQP_DEFAULT_FRAME_SIZE
- * \param [in] heartbeat the number of seconds between heartbeat frame to
- *             request of the broker. A value of 0 disables heartbeats.
- *             Note rabbitmq-c only has partial support for hearts, as of
- *             v0.4.0 heartbeats are only serviced during amqp_basic_publish(),
- *             and amqp_simple_wait_frame()/amqp_simple_wait_frame_noblock()
- * \param [in] properties a table of properties to send the broker.
- * \param [in] timeout a timeout to wait for a start connection. Passing in
- *             NULL will result in blocking behavior.
- * \param [in] sasl_method the SASL method to authenticate with the broker
- *             followed by the authentication information.
- *             For AMQP_SASL_METHOD_PLAN, the AMQP_SASL_METHOD_PLAIN parameter
- *             should be followed by two arguments in this order:
- *             const char* username, and const char* password.
- * \return amqp_rpc_reply_t indicating success or failure.
- *  - r.reply_type == AMQP_RESPONSE_NORMAL. Login completed successfully
- *  - r.reply_type == AMQP_RESPONSE_LIBRARY_EXCEPTION. In most cases errors
- *    from the broker when logging in will be represented by the broker closing
- *    the socket. In this case r.library_error will be set to
- *    AMQP_STATUS_CONNECTION_CLOSED. This error can represent a number of
- *    error conditions including: invalid vhost, authentication failure.
- *  - r.reply_type == AMQP_STATUS_TIMEOUT the timeout was reached while waiting
- *    for start connection.
- *  - r.reply_type == AMQP_RESPONSE_SERVER_EXCEPTION. The broker returned an
- *    exception:
- *    - If r.reply.id == AMQP_CHANNEL_CLOSE_METHOD a channel exception
- *      occurred, cast r.reply.decoded to amqp_channel_close_t* to see details
- *      of the exception. The client should amqp_send_method() a
- *      amqp_channel_close_ok_t. The channel must be re-opened before it
- *      can be used again. Any resources associated with the channel
- *      (auto-delete exchanges, auto-delete queues, consumers) are invalid
- *      and must be recreated before attempting to use them again.
- *    - If r.reply.id == AMQP_CONNECTION_CLOSE_METHOD a connection exception
- *      occurred, cast r.reply.decoded to amqp_connection_close_t* to see
- *      details of the exception. The client amqp_send_method() a
- *      amqp_connection_close_ok_t and disconnect from the broker.
- *
- * \since v0.8.1
- */
-AMQP_PUBLIC_FUNCTION
-amqp_rpc_reply_t
-AMQP_CALL amqp_login_with_properties_noblock(amqp_connection_state_t state,
-                                             char const *vhost,
-                                             int channel_max, int frame_max,
-                                             int heartbeat,
-                                             const amqp_table_t *properties,
-                                             struct timeval *timeout,
-                                             amqp_sasl_method_enum sasl_method,
-                                             ...);
-
 struct amqp_basic_properties_t_;
 
 /**
@@ -2507,6 +2439,37 @@ amqp_get_server_properties(amqp_connection_state_t state);
 AMQP_PUBLIC_FUNCTION
 amqp_table_t *
 amqp_get_client_properties(amqp_connection_state_t state);
+
+/**
+ * Get the current value of the handshake timeout.
+ *
+ * \param [in] state the connection object
+ * \return a pointer to a struct timeval containing the current value of the
+ * handshake timeout set for current state. Return NULL if current timeout is
+ * set to the infinite value.
+ *
+ * \since v0.8.2
+ */
+AMQP_PUBLIC_FUNCTION
+struct timeval *
+AMQP_CALL amqp_get_handshake_timeout(amqp_connection_state_t state);
+
+/**
+ * Set the new value for the handshake timeout.
+ *
+ * \param [in] state the connection object
+ * \param [in] timeout a pointer to a struct timeval containing value of the
+ * handshake timeout that has to be set for current state. By default timeout
+ * is pointed to the static struct timeval initialized with 20000 ms.
+ * Initialize timeout == NULL to set infinite handshake timeout.
+ * \return AMQP_STATUS_OK.
+ *
+ * \since v0.8.2
+ */
+AMQP_PUBLIC_FUNCTION
+int
+AMQP_CALL amqp_set_handshake_timeout(amqp_connection_state_t state,
+                                     struct timeval *timeout);
 
 AMQP_END_DECLS
 

--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -1865,6 +1865,73 @@ AMQP_CALL amqp_login_with_properties(amqp_connection_state_t state, char const *
                                      int channel_max, int frame_max, int heartbeat,
                                      const amqp_table_t *properties, amqp_sasl_method_enum sasl_method, ...);
 
+/**
+ * Login to the broker passing a properties table with a timeout
+ *
+ * This function is similar to amqp_login() and differs in that it provides a
+ * way to pass client properties to the broker. This is commonly used to
+ * negotiate newer protocol features as they are supported by the broker.
+ *
+ * \param [in] state the connection object
+ * \param [in] vhost the virtual host to connect to on the broker. The default
+ *              on most brokers is "/"
+ * \param [in] channel_max the limit for the number of channels for the connection.
+ *             0 means no limit, and is a good default (AMQP_DEFAULT_MAX_CHANNELS)
+ *             Note that the maximum number of channels the protocol supports
+ *             is 65535 (2^16, with the 0-channel reserved)
+ * \param [in] frame_max the maximum size of an AMQP frame ont he wire to
+ *              request of the broker for this connection. 4096 is the minimum
+ *              size, 2^31-1 is the maximum, a good default is 131072 (128KB), or
+ *              AMQP_DEFAULT_FRAME_SIZE
+ * \param [in] heartbeat the number of seconds between heartbeat frame to
+ *             request of the broker. A value of 0 disables heartbeats.
+ *             Note rabbitmq-c only has partial support for hearts, as of
+ *             v0.4.0 heartbeats are only serviced during amqp_basic_publish(),
+ *             and amqp_simple_wait_frame()/amqp_simple_wait_frame_noblock()
+ * \param [in] properties a table of properties to send the broker.
+ * \param [in] timeout a timeout to wait for a start connection. Passing in
+ *             NULL will result in blocking behavior.
+ * \param [in] sasl_method the SASL method to authenticate with the broker
+ *             followed by the authentication information.
+ *             For AMQP_SASL_METHOD_PLAN, the AMQP_SASL_METHOD_PLAIN parameter
+ *             should be followed by two arguments in this order:
+ *             const char* username, and const char* password.
+ * \return amqp_rpc_reply_t indicating success or failure.
+ *  - r.reply_type == AMQP_RESPONSE_NORMAL. Login completed successfully
+ *  - r.reply_type == AMQP_RESPONSE_LIBRARY_EXCEPTION. In most cases errors
+ *    from the broker when logging in will be represented by the broker closing
+ *    the socket. In this case r.library_error will be set to
+ *    AMQP_STATUS_CONNECTION_CLOSED. This error can represent a number of
+ *    error conditions including: invalid vhost, authentication failure.
+ *  - r.reply_type == AMQP_STATUS_TIMEOUT the timeout was reached while waiting
+ *    for start connection.
+ *  - r.reply_type == AMQP_RESPONSE_SERVER_EXCEPTION. The broker returned an
+ *    exception:
+ *    - If r.reply.id == AMQP_CHANNEL_CLOSE_METHOD a channel exception
+ *      occurred, cast r.reply.decoded to amqp_channel_close_t* to see details
+ *      of the exception. The client should amqp_send_method() a
+ *      amqp_channel_close_ok_t. The channel must be re-opened before it
+ *      can be used again. Any resources associated with the channel
+ *      (auto-delete exchanges, auto-delete queues, consumers) are invalid
+ *      and must be recreated before attempting to use them again.
+ *    - If r.reply.id == AMQP_CONNECTION_CLOSE_METHOD a connection exception
+ *      occurred, cast r.reply.decoded to amqp_connection_close_t* to see
+ *      details of the exception. The client amqp_send_method() a
+ *      amqp_connection_close_ok_t and disconnect from the broker.
+ *
+ * \since v0.8.1
+ */
+AMQP_PUBLIC_FUNCTION
+amqp_rpc_reply_t
+AMQP_CALL amqp_login_with_properties_noblock(amqp_connection_state_t state,
+                                             char const *vhost,
+                                             int channel_max, int frame_max,
+                                             int heartbeat,
+                                             const amqp_table_t *properties,
+                                             struct timeval *timeout,
+                                             amqp_sasl_method_enum sasl_method,
+                                             ...);
+
 struct amqp_basic_properties_t_;
 
 /**

--- a/librabbitmq/amqp_api.c
+++ b/librabbitmq/amqp_api.c
@@ -355,3 +355,16 @@ int amqp_basic_nack(amqp_connection_state_t state, amqp_channel_t channel,
   req.requeue = requeue;
   return amqp_send_method(state, channel, AMQP_BASIC_NACK_METHOD, &req);
 }
+
+struct timeval *
+AMQP_CALL amqp_get_handshake_timeout(amqp_connection_state_t state)
+{
+  return state->handshake_timeout;
+}
+
+int AMQP_CALL amqp_set_handshake_timeout(amqp_connection_state_t state,
+                                         struct timeval *timeout)
+{
+  state->handshake_timeout = timeout;
+  return AMQP_STATUS_OK;
+}

--- a/librabbitmq/amqp_api.c
+++ b/librabbitmq/amqp_api.c
@@ -207,9 +207,9 @@ int amqp_basic_publish(amqp_connection_state_t state,
     }
   }
 
-  res = amqp_send_method_inner_noblock(state, channel,
-                                       AMQP_BASIC_PUBLISH_METHOD, &m,
-                                       AMQP_SF_MORE, NULL);
+  res = amqp_send_method_inner(state, channel,
+                               AMQP_BASIC_PUBLISH_METHOD, &m,
+                               AMQP_SF_MORE, NULL);
   if (res < 0) {
     return res;
   }

--- a/librabbitmq/amqp_api.c
+++ b/librabbitmq/amqp_api.c
@@ -357,14 +357,20 @@ int amqp_basic_nack(amqp_connection_state_t state, amqp_channel_t channel,
 }
 
 struct timeval *
-AMQP_CALL amqp_get_handshake_timeout(amqp_connection_state_t state)
+amqp_get_handshake_timeout(amqp_connection_state_t state)
 {
   return state->handshake_timeout;
 }
 
-int AMQP_CALL amqp_set_handshake_timeout(amqp_connection_state_t state,
-                                         struct timeval *timeout)
+int amqp_set_handshake_timeout(amqp_connection_state_t state,
+                               struct timeval *timeout)
 {
-  state->handshake_timeout = timeout;
+  if (timeout) {
+    state->internal_handshake_timeout = *timeout;
+    state->handshake_timeout = &state->internal_handshake_timeout;
+  } else {
+    state->handshake_timeout = NULL;
+  }
+  
   return AMQP_STATUS_OK;
 }

--- a/librabbitmq/amqp_api.c
+++ b/librabbitmq/amqp_api.c
@@ -209,7 +209,7 @@ int amqp_basic_publish(amqp_connection_state_t state,
 
   res = amqp_send_method_inner(state, channel,
                                AMQP_BASIC_PUBLISH_METHOD, &m,
-                               AMQP_SF_MORE, NULL);
+                               AMQP_SF_MORE, amqp_time_infinite());
   if (res < 0) {
     return res;
   }
@@ -225,7 +225,7 @@ int amqp_basic_publish(amqp_connection_state_t state,
   f.payload.properties.body_size = body.len;
   f.payload.properties.decoded = (void *) properties;
 
-  res = amqp_send_frame_inner(state, &f, AMQP_SF_MORE, NULL);
+  res = amqp_send_frame_inner(state, &f, AMQP_SF_MORE, amqp_time_infinite());
   if (res < 0) {
     return res;
   }
@@ -251,7 +251,7 @@ int amqp_basic_publish(amqp_connection_state_t state,
     }
 
     body_offset += f.payload.body_fragment.len;
-    res = amqp_send_frame_inner(state, &f, flagz, NULL);
+    res = amqp_send_frame_inner(state, &f, flagz, amqp_time_infinite());
     if (res < 0) {
       return res;
     }

--- a/librabbitmq/amqp_api.c
+++ b/librabbitmq/amqp_api.c
@@ -225,7 +225,7 @@ int amqp_basic_publish(amqp_connection_state_t state,
   f.payload.properties.body_size = body.len;
   f.payload.properties.decoded = (void *) properties;
 
-  res = amqp_send_frame_inner_noblock(state, &f, AMQP_SF_MORE, NULL);
+  res = amqp_send_frame_inner(state, &f, AMQP_SF_MORE, NULL);
   if (res < 0) {
     return res;
   }
@@ -251,7 +251,7 @@ int amqp_basic_publish(amqp_connection_state_t state,
     }
 
     body_offset += f.payload.body_fragment.len;
-    res = amqp_send_frame_inner_noblock(state, &f, flagz, NULL);
+    res = amqp_send_frame_inner(state, &f, flagz, NULL);
     if (res < 0) {
       return res;
     }

--- a/librabbitmq/amqp_api.c
+++ b/librabbitmq/amqp_api.c
@@ -207,8 +207,9 @@ int amqp_basic_publish(amqp_connection_state_t state,
     }
   }
 
-  res = amqp_send_method_inner(state, channel, AMQP_BASIC_PUBLISH_METHOD, &m,
-                               AMQP_SF_MORE);
+  res = amqp_send_method_inner_noblock(state, channel,
+                                       AMQP_BASIC_PUBLISH_METHOD, &m,
+                                       AMQP_SF_MORE, NULL);
   if (res < 0) {
     return res;
   }
@@ -224,7 +225,7 @@ int amqp_basic_publish(amqp_connection_state_t state,
   f.payload.properties.body_size = body.len;
   f.payload.properties.decoded = (void *) properties;
 
-  res = amqp_send_frame_inner(state, &f, AMQP_SF_MORE);
+  res = amqp_send_frame_inner_noblock(state, &f, AMQP_SF_MORE, NULL);
   if (res < 0) {
     return res;
   }
@@ -250,7 +251,7 @@ int amqp_basic_publish(amqp_connection_state_t state,
     }
 
     body_offset += f.payload.body_fragment.len;
-    res = amqp_send_frame_inner(state, &f, flagz);
+    res = amqp_send_frame_inner_noblock(state, &f, flagz, NULL);
     if (res < 0) {
       return res;
     }

--- a/librabbitmq/amqp_connection.c
+++ b/librabbitmq/amqp_connection.c
@@ -59,9 +59,6 @@
 #define AMQP_INITIAL_INBOUND_SOCK_BUFFER_SIZE 131072
 #endif
 
-#define DEFAULT_HANDSHAKE_TIMEOUT_SEC 20
-static struct timeval default_handshake_timeout = {DEFAULT_HANDSHAKE_TIMEOUT_SEC, 0};
-
 #define ENFORCE_STATE(statevec, statenum)                                   \
   {                                                                         \
     amqp_connection_state_t _check_state = (statevec);                      \
@@ -104,8 +101,9 @@ amqp_connection_state_t amqp_new_connection(void)
 
   init_amqp_pool(&state->properties_pool, 512);
 
-  /*Use address of the static default_timeout object by default. */
-  state->handshake_timeout = &default_handshake_timeout;
+  /* Use address of the internal_handshake_timeout object by default. */
+  state->internal_handshake_timeout = {20, 0};
+  state->handshake_timeout = &state->internal_handshake_timeout;
 
   return state;
 

--- a/librabbitmq/amqp_connection.c
+++ b/librabbitmq/amqp_connection.c
@@ -102,7 +102,8 @@ amqp_connection_state_t amqp_new_connection(void)
   init_amqp_pool(&state->properties_pool, 512);
 
   /* Use address of the internal_handshake_timeout object by default. */
-  state->internal_handshake_timeout = {20, 0};
+  state->internal_handshake_timeout.tv_sec = 20;
+  state->internal_handshake_timeout.tv_usec = 0;
   state->handshake_timeout = &state->internal_handshake_timeout;
 
   return state;

--- a/librabbitmq/amqp_connection.c
+++ b/librabbitmq/amqp_connection.c
@@ -537,12 +537,12 @@ static int amqp_frame_to_bytes(const amqp_frame_t *frame, amqp_bytes_t buffer,
 
 int amqp_send_frame(amqp_connection_state_t state,
                     const amqp_frame_t *frame) {
-  return amqp_send_frame_inner(state, frame, AMQP_SF_NONE, NULL);
+  return amqp_send_frame_inner(state, frame, AMQP_SF_NONE, amqp_time_infinite());
 }
 
 int amqp_send_frame_inner(amqp_connection_state_t state,
                           const amqp_frame_t *frame, int flags,
-                          struct timeval * timeout) {
+                          amqp_time_t deadline) {
   int res;
   ssize_t sent;
   amqp_bytes_t encoded;
@@ -556,11 +556,6 @@ int amqp_send_frame_inner(amqp_connection_state_t state,
    * would need to be done to see if this would actually a win for performance.
    * */
   res = amqp_frame_to_bytes(frame, state->outbound_buffer, &encoded);
-  if (AMQP_STATUS_OK != res) {
-    return res;
-  }
-
-  res = amqp_time_from_now(&deadline, timeout);
   if (AMQP_STATUS_OK != res) {
     return res;
   }

--- a/librabbitmq/amqp_connection.c
+++ b/librabbitmq/amqp_connection.c
@@ -537,12 +537,12 @@ static int amqp_frame_to_bytes(const amqp_frame_t *frame, amqp_bytes_t buffer,
 
 int amqp_send_frame(amqp_connection_state_t state,
                     const amqp_frame_t *frame) {
-  return amqp_send_frame_inner_noblock(state, frame, AMQP_SF_NONE, NULL);
+  return amqp_send_frame_inner(state, frame, AMQP_SF_NONE, NULL);
 }
 
-int amqp_send_frame_inner_noblock(amqp_connection_state_t state,
-                                  const amqp_frame_t *frame, int flags,
-                                  struct timeval * timeout) {
+int amqp_send_frame_inner(amqp_connection_state_t state,
+                          const amqp_frame_t *frame, int flags,
+                          struct timeval * timeout) {
   int res;
   ssize_t sent;
   amqp_bytes_t encoded;

--- a/librabbitmq/amqp_connection.c
+++ b/librabbitmq/amqp_connection.c
@@ -548,7 +548,7 @@ int amqp_send_frame_inner_noblock(amqp_connection_state_t state,
   amqp_bytes_t encoded;
   amqp_time_t deadline;
   amqp_time_t min_timeout;
-  int timout_flag = 0;
+  int timeout_flag = 0;
 
   /* TODO: if the AMQP_SF_MORE socket optimization can be shown to work
    * correctly, then this could be un-done so that body-frames are sent as 3

--- a/librabbitmq/amqp_connection.c
+++ b/librabbitmq/amqp_connection.c
@@ -59,6 +59,9 @@
 #define AMQP_INITIAL_INBOUND_SOCK_BUFFER_SIZE 131072
 #endif
 
+#define DEFAULT_HANDSHAKE_TIMEOUT_SEC = 20
+static struct timeval default_handshake_timeout = {DEFAULT_HANDSHAKE_TIMEOUT_SEC, 0};
+
 #define ENFORCE_STATE(statevec, statenum)                                   \
   {                                                                         \
     amqp_connection_state_t _check_state = (statevec);                      \
@@ -100,6 +103,9 @@ amqp_connection_state_t amqp_new_connection(void)
   }
 
   init_amqp_pool(&state->properties_pool, 512);
+
+  /*Use address of the static default_timeout object by default. */
+  state->handshake_timeout = &default_handshake_timeout;
 
   return state;
 

--- a/librabbitmq/amqp_connection.c
+++ b/librabbitmq/amqp_connection.c
@@ -59,7 +59,7 @@
 #define AMQP_INITIAL_INBOUND_SOCK_BUFFER_SIZE 131072
 #endif
 
-#define DEFAULT_HANDSHAKE_TIMEOUT_SEC = 20
+#define DEFAULT_HANDSHAKE_TIMEOUT_SEC 20
 static struct timeval default_handshake_timeout = {DEFAULT_HANDSHAKE_TIMEOUT_SEC, 0};
 
 #define ENFORCE_STATE(statevec, statenum)                                   \

--- a/librabbitmq/amqp_connection.c
+++ b/librabbitmq/amqp_connection.c
@@ -546,7 +546,6 @@ int amqp_send_frame_inner(amqp_connection_state_t state,
   int res;
   ssize_t sent;
   amqp_bytes_t encoded;
-  amqp_time_t deadline;
   amqp_time_t min_timeout;
   int timeout_flag = 0;
 

--- a/librabbitmq/amqp_private.h
+++ b/librabbitmq/amqp_private.h
@@ -387,6 +387,7 @@ static inline amqp_rpc_reply_t amqp_rpc_reply_error(amqp_status_enum status) {
   return reply;
 }
 
-int amqp_send_frame_inner(amqp_connection_state_t state,
-                          const amqp_frame_t *frame, int flags);
+int amqp_send_frame_inner_noblock(amqp_connection_state_t state,
+                                  const amqp_frame_t *frame, int flags,
+                                  struct timeval * timeout);
 #endif

--- a/librabbitmq/amqp_private.h
+++ b/librabbitmq/amqp_private.h
@@ -387,7 +387,7 @@ static inline amqp_rpc_reply_t amqp_rpc_reply_error(amqp_status_enum status) {
   return reply;
 }
 
-int amqp_send_frame_inner_noblock(amqp_connection_state_t state,
-                                  const amqp_frame_t *frame, int flags,
-                                  struct timeval * timeout);
+int amqp_send_frame_inner(amqp_connection_state_t state,
+                          const amqp_frame_t *frame, int flags,
+                          struct timeval * timeout);
 #endif

--- a/librabbitmq/amqp_private.h
+++ b/librabbitmq/amqp_private.h
@@ -195,6 +195,7 @@ struct amqp_connection_state_t_ {
   amqp_pool_t properties_pool;
 
   struct timeval *handshake_timeout;
+  struct timeval internal_handshake_timeout;
 };
 
 amqp_pool_t *amqp_get_or_create_channel_pool(amqp_connection_state_t connection, amqp_channel_t channel);

--- a/librabbitmq/amqp_private.h
+++ b/librabbitmq/amqp_private.h
@@ -193,6 +193,8 @@ struct amqp_connection_state_t_ {
   amqp_table_t server_properties;
   amqp_table_t client_properties;
   amqp_pool_t properties_pool;
+
+  struct timeval *handshake_timeout;
 };
 
 amqp_pool_t *amqp_get_or_create_channel_pool(amqp_connection_state_t connection, amqp_channel_t channel);

--- a/librabbitmq/amqp_private.h
+++ b/librabbitmq/amqp_private.h
@@ -389,5 +389,5 @@ static inline amqp_rpc_reply_t amqp_rpc_reply_error(amqp_status_enum status) {
 
 int amqp_send_frame_inner(amqp_connection_state_t state,
                           const amqp_frame_t *frame, int flags,
-                          struct timeval * timeout);
+                          amqp_time_t deadline);
 #endif

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -1029,7 +1029,7 @@ int amqp_simple_wait_method_noblock(amqp_connection_state_t state,
                                     struct timeval *timeout,
                                     amqp_method_t *output)
 {
-  amqp_method_number_t expected_methods[] = { 0, 0 };
+  amqp_method_number_t expected_methods[] = { expected_method, 0 };
   expected_methods[0] = expected_method;
   return amqp_simple_wait_method_list_noblock(state, expected_channel,
                                               expected_methods,

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -549,7 +549,7 @@ int amqp_send_header_noblock(amqp_connection_state_t state, amqp_time_t deadline
                                      AMQP_PROTOCOL_VERSION_MINOR,
                                      AMQP_PROTOCOL_VERSION_REVISION
                                    };
-  res = amqp_try_send(state, header, sizeof(header), amqp_time_infinite(),
+  res = amqp_try_send(state, header, sizeof(header), deadline,
                       AMQP_SF_NONE);
   if (sizeof(header) == res) {
     return AMQP_STATUS_OK;
@@ -559,7 +559,7 @@ int amqp_send_header_noblock(amqp_connection_state_t state, amqp_time_t deadline
 
 int amqp_send_header(amqp_connection_state_t state)
 {
-  return amqp_send_header_noblock(amqp_connection_state_t state, amqp_time_infinite());
+  return amqp_send_header_noblock(state, amqp_time_infinite());
 }
 
 static amqp_bytes_t sasl_method_name(amqp_sasl_method_enum method)

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -541,7 +541,8 @@ int amqp_open_socket_inner(char const *hostname,
   return sockfd;
 }
 
-int amqp_send_header_noblock(amqp_connection_state_t state, amqp_time_t deadline)
+static int amqp_send_header_noblock(amqp_connection_state_t state,
+                                    amqp_time_t deadline)
 {
   ssize_t res;
   static const uint8_t header[8] = { 'A', 'M', 'Q', 'P', 0,
@@ -1030,7 +1031,6 @@ int amqp_simple_wait_method_noblock(amqp_connection_state_t state,
                                     amqp_method_t *output)
 {
   amqp_method_number_t expected_methods[] = { expected_method, 0 };
-  expected_methods[0] = expected_method;
   return amqp_simple_wait_method_list(state, expected_channel,
                                       expected_methods, deadline, output);
 }
@@ -1077,11 +1077,11 @@ static int amqp_id_in_reply_list( amqp_method_number_t expected, amqp_method_num
 }
 
 amqp_rpc_reply_t amqp_simple_rpc_noblock(amqp_connection_state_t state,
-                                         amqp_channel_t channel,
-                                         amqp_method_number_t request_id,
-                                         amqp_method_number_t *expected_reply_ids,
-                                         void *decoded_request_method,
-                                         amqp_time_t deadline)
+                                     amqp_channel_t channel,
+                                     amqp_method_number_t request_id,
+                                     amqp_method_number_t *expected_reply_ids,
+                                     void *decoded_request_method,
+                                     amqp_time_t deadline)
 {
   int status;
   amqp_rpc_reply_t result;
@@ -1208,8 +1208,9 @@ void *amqp_simple_rpc_decoded(amqp_connection_state_t state,
                               amqp_method_number_t reply_id,
                               void *decoded_request_method)
 {
-  return amqp_simple_rpc_decoded_noblock(state, channel, request_id, reply_id,
-                                         decoded_request_method, amqp_time_infinite());
+  return amqp_simple_rpc_decoded_noblock(state, channel, request_id,
+                                         reply_id, decoded_request_method,
+                                         amqp_time_infinite());
 }
 
 amqp_rpc_reply_t amqp_get_rpc_reply(amqp_connection_state_t state)
@@ -1541,13 +1542,13 @@ amqp_rpc_reply_t amqp_login(amqp_connection_state_t state,
 }
 
 amqp_rpc_reply_t amqp_login_with_properties(amqp_connection_state_t state,
-                                            char const *vhost,
-                                            int channel_max,
-                                            int frame_max,
-                                            int heartbeat,
-                                            const amqp_table_t *client_properties,
-                                            amqp_sasl_method_enum sasl_method,
-                                            ...)
+    char const *vhost,
+    int channel_max,
+    int frame_max,
+    int heartbeat,
+    const amqp_table_t *client_properties,
+    amqp_sasl_method_enum sasl_method,
+    ...)
 {
   va_list vl;
   amqp_rpc_reply_t ret;

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -1098,7 +1098,7 @@ amqp_rpc_reply_t amqp_simple_rpc_noblock(amqp_connection_state_t state,
     amqp_frame_t frame;
 
 retry:
-    status = wait_frame_inner(state, &frame, timeout);
+    status = wait_frame_inner(state, &frame, deadline);
     if (status < 0) {
       result.reply_type = AMQP_RESPONSE_LIBRARY_EXCEPTION;
       result.library_error = status;

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -993,7 +993,7 @@ int amqp_simple_wait_frame_noblock(amqp_connection_state_t state,
   }
 }
 
-static int amqp_simple_wait_method_list_noblock(amqp_connection_state_t state,
+static int amqp_simple_wait_method_list(amqp_connection_state_t state,
                                        amqp_channel_t expected_channel,
                                        amqp_method_number_t *expected_methods,
                                        struct timeval *timeout,
@@ -1014,15 +1014,6 @@ static int amqp_simple_wait_method_list_noblock(amqp_connection_state_t state,
   return AMQP_STATUS_OK;
 }
 
-static int amqp_simple_wait_method_list(amqp_connection_state_t state,
-                                        amqp_channel_t expected_channel,
-                                        amqp_method_number_t *expected_methods,
-                                        amqp_method_t *output)
-{
-  return amqp_simple_wait_method_list_noblock(state, expected_channel, 
-                                              expected_methods, NULL, output);
-}
-
 int amqp_simple_wait_method_noblock(amqp_connection_state_t state,
                                     amqp_channel_t expected_channel,
                                     amqp_method_number_t expected_method,
@@ -1031,9 +1022,8 @@ int amqp_simple_wait_method_noblock(amqp_connection_state_t state,
 {
   amqp_method_number_t expected_methods[] = { expected_method, 0 };
   expected_methods[0] = expected_method;
-  return amqp_simple_wait_method_list_noblock(state, expected_channel,
-                                              expected_methods,
-                                              timeout, output);
+  return amqp_simple_wait_method_list(state, expected_channel,
+                                      expected_methods, timeout, output);
 }
 
 int amqp_simple_wait_method(amqp_connection_state_t state,
@@ -1444,8 +1434,7 @@ static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
       goto error_res;
     }
 
-    res = amqp_simple_wait_method_list_noblock(state, 0, expected,
-                                               tvp, &method);
+    res = amqp_simple_wait_method_list(state, 0, expected, tvp, &method);
     if (AMQP_STATUS_OK != res) {
       goto error_res;
     }

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -1047,15 +1047,15 @@ int amqp_simple_wait_method(amqp_connection_state_t state,
 
 int amqp_send_method(amqp_connection_state_t state, amqp_channel_t channel,
                      amqp_method_number_t id, void *decoded) {
-  return amqp_send_method_inner_noblock(state, channel, id, decoded,
-                                        AMQP_SF_NONE, NULL);
+  return amqp_send_method_inner(state, channel, id, decoded,
+                                AMQP_SF_NONE, NULL);
 }
 
-int amqp_send_method_inner_noblock(amqp_connection_state_t state,
-                                   amqp_channel_t channel,
-                                   amqp_method_number_t id,
-                                   void *decoded, int flags,
-                                   struct timeval * timeout) {
+int amqp_send_method_inner(amqp_connection_state_t state,
+                           amqp_channel_t channel,
+                           amqp_method_number_t id,
+                           void *decoded, int flags,
+                           struct timeval * timeout) {
   amqp_frame_t frame;
 
   frame.frame_type = AMQP_FRAME_METHOD;
@@ -1426,9 +1426,8 @@ static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
       goto error_res;
     }
 
-    res = amqp_send_method_inner_noblock(state, 0, 
-                                         AMQP_CONNECTION_START_OK_METHOD,
-                                         &s, AMQP_SF_NONE, tvp);
+    res = amqp_send_method_inner(state, 0, AMQP_CONNECTION_START_OK_METHOD,
+                                 &s, AMQP_SF_NONE, tvp);
     if (res < 0) {
       goto error_res;
     }
@@ -1498,9 +1497,8 @@ static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
       goto error_res;
     }
 
-    res = amqp_send_method_inner_noblock(state, 0, 
-                                         AMQP_CONNECTION_TUNE_OK_METHOD,
-                                         &s, AMQP_SF_NONE, tvp);
+    res = amqp_send_method_inner(state, 0, AMQP_CONNECTION_TUNE_OK_METHOD,
+                                 &s, AMQP_SF_NONE, tvp);
     if (res < 0) {
       goto error_res;
     }

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -1534,7 +1534,7 @@ amqp_rpc_reply_t amqp_login(amqp_connection_state_t state,
   va_start(vl, sasl_method);
 
   ret = amqp_login_inner(state, vhost, channel_max, frame_max, heartbeat,
-    &amqp_empty_table, NULL, sasl_method, vl);
+    &amqp_empty_table, state->handshake_timeout, sasl_method, vl);
 
   va_end(vl);
 
@@ -1556,31 +1556,7 @@ amqp_rpc_reply_t amqp_login_with_properties(amqp_connection_state_t state,
   va_start(vl, sasl_method);
 
   ret = amqp_login_inner(state, vhost, channel_max, frame_max, heartbeat,
-    client_properties, NULL, sasl_method, vl);
-
-  va_end(vl);
-
-  return ret;
-}
-
-amqp_rpc_reply_t amqp_login_with_properties_noblock(
-                      amqp_connection_state_t state,
-                      char const *vhost,
-                      int channel_max,
-                      int frame_max,
-                      int heartbeat,
-                      const amqp_table_t *client_properties,
-                      struct timeval *timeout,
-                      amqp_sasl_method_enum sasl_method,
-                      ...)
-{
-  va_list vl;
-  amqp_rpc_reply_t ret;
-
-  va_start(vl, sasl_method);
-
-  ret = amqp_login_inner(state, vhost, channel_max, frame_max, heartbeat,
-                         client_properties, timeout, sasl_method, vl);
+    client_properties, state->handshake_timeout, sasl_method, vl);
 
   va_end(vl);
 

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -1423,7 +1423,9 @@ static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
       goto error_res;
     }
 
-    res = amqp_send_method_inner_noblock(state, 0, AMQP_CONNECTION_START_OK_METHOD, &s, tvp);
+    res = amqp_send_method_inner_noblock(state, 0, 
+                                         AMQP_CONNECTION_START_OK_METHOD,
+                                         &s, AMQP_SF_NONE, tvp);
     if (res < 0) {
       goto error_res;
     }
@@ -1492,7 +1494,9 @@ static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
       goto error_res;
     }
 
-    res = amqp_send_method_inner_noblock(state, 0, AMQP_CONNECTION_TUNE_OK_METHOD, &s, tvp);
+    res = amqp_send_method_inner_noblock(state, 0, 
+                                         AMQP_CONNECTION_TUNE_OK_METHOD,
+                                         &s, AMQP_SF_NONE, tvp);
     if (res < 0) {
       goto error_res;
     }

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -549,8 +549,7 @@ int amqp_send_header_noblock(amqp_connection_state_t state, amqp_time_t deadline
                                      AMQP_PROTOCOL_VERSION_MINOR,
                                      AMQP_PROTOCOL_VERSION_REVISION
                                    };
-  res = amqp_try_send(state, header, sizeof(header), deadline,
-                      AMQP_SF_NONE);
+  res = amqp_try_send(state, header, sizeof(header), deadline, AMQP_SF_NONE);
   if (sizeof(header) == res) {
     return AMQP_STATUS_OK;
   }
@@ -995,10 +994,10 @@ int amqp_simple_wait_frame_noblock(amqp_connection_state_t state,
 }
 
 static int amqp_simple_wait_method_list_noblock(amqp_connection_state_t state,
-                                                amqp_channel_t expected_channel,
-                                                amqp_method_number_t *expected_methods,
-                                                struct timeval *timeout,
-                                                amqp_method_t *output)
+                                       amqp_channel_t expected_channel,
+                                       amqp_method_number_t *expected_methods,
+                                       struct timeval *timeout,
+                                       amqp_method_t *output)
 {
   amqp_frame_t frame;
   int res = amqp_simple_wait_frame_noblock(state, &frame, timeout);
@@ -1007,8 +1006,8 @@ static int amqp_simple_wait_method_list_noblock(amqp_connection_state_t state,
   }
 
   if (AMQP_FRAME_METHOD != frame.frame_type ||
-    expected_channel != frame.channel ||
-    !amqp_id_in_reply_list(frame.payload.method.id, expected_methods)) {
+      expected_channel != frame.channel ||
+      !amqp_id_in_reply_list(frame.payload.method.id, expected_methods)) {
     return AMQP_STATUS_WRONG_METHOD;
   }
   *output = frame.payload.method;
@@ -1020,7 +1019,8 @@ static int amqp_simple_wait_method_list(amqp_connection_state_t state,
                                         amqp_method_number_t *expected_methods,
                                         amqp_method_t *output)
 {
-  return amqp_simple_wait_method_list_noblock(state, expected_channel, expected_methods, NULL, output);
+  return amqp_simple_wait_method_list_noblock(state, expected_channel, 
+                                              expected_methods, NULL, output);
 }
 
 int amqp_simple_wait_method_noblock(amqp_connection_state_t state,
@@ -1031,7 +1031,8 @@ int amqp_simple_wait_method_noblock(amqp_connection_state_t state,
 {
   amqp_method_number_t expected_methods[] = { 0, 0 };
   expected_methods[0] = expected_method;
-  return amqp_simple_wait_method_list_noblock(state, expected_channel, expected_methods,
+  return amqp_simple_wait_method_list_noblock(state, expected_channel,
+                                              expected_methods,
                                               timeout, output);
 }
 
@@ -1040,12 +1041,14 @@ int amqp_simple_wait_method(amqp_connection_state_t state,
                             amqp_method_number_t expected_method,
                             amqp_method_t *output)
 {
-  return amqp_simple_wait_method_noblock(state, expected_channel, expected_method, NULL, output);
+  return amqp_simple_wait_method_noblock(state, expected_channel,
+                                         expected_method, NULL, output);
 }
 
 int amqp_send_method(amqp_connection_state_t state, amqp_channel_t channel,
                      amqp_method_number_t id, void *decoded) {
-  return amqp_send_method_inner_noblock(state, channel, id, decoded, AMQP_SF_NONE, NULL);
+  return amqp_send_method_inner_noblock(state, channel, id, decoded,
+                                        AMQP_SF_NONE, NULL);
 }
 
 int amqp_send_method_inner_noblock(amqp_connection_state_t state,
@@ -1059,7 +1062,7 @@ int amqp_send_method_inner_noblock(amqp_connection_state_t state,
   frame.channel = channel;
   frame.payload.method.id = id;
   frame.payload.method.decoded = decoded;
-  return amqp_send_frame_inner_noblock(state, &frame, flags, timeout);
+  return amqp_send_frame_inner(state, &frame, flags, timeout);
 }
 
 static int amqp_id_in_reply_list( amqp_method_number_t expected, amqp_method_number_t *list )
@@ -1442,7 +1445,8 @@ static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
       goto error_res;
     }
 
-    res = amqp_simple_wait_method_list_noblock(state, 0, expected, tvp, &method);
+    res = amqp_simple_wait_method_list_noblock(state, 0, expected,
+                                               tvp, &method);
     if (AMQP_STATUS_OK != res) {
       goto error_res;
     }
@@ -1545,7 +1549,6 @@ error_res:
   goto out;
 }
 
-
 amqp_rpc_reply_t amqp_login(amqp_connection_state_t state,
                             char const *vhost,
                             int channel_max,
@@ -1566,7 +1569,6 @@ amqp_rpc_reply_t amqp_login(amqp_connection_state_t state,
 
   return ret;
 }
-
 
 amqp_rpc_reply_t amqp_login_with_properties(amqp_connection_state_t state,
                                             char const *vhost,

--- a/librabbitmq/amqp_socket.h
+++ b/librabbitmq/amqp_socket.h
@@ -288,9 +288,12 @@ amqp_simple_rpc_decoded_noblock(amqp_connection_state_t state,
                                 void *decoded_request_method,
                                 struct timeval *timeout);
 
-int amqp_send_method_inner(amqp_connection_state_t state,
-                           amqp_channel_t channel, amqp_method_number_t id,
-                           void *decoded, int flags);
+int amqp_send_method_inner_noblock(amqp_connection_state_t state,
+                                   amqp_channel_t channel,
+                                   amqp_method_number_t id,
+                                   void *decoded, int flags,
+                                   struct timeval *timeout);
+
 int
 amqp_queue_frame(amqp_connection_state_t state, amqp_frame_t *frame);
 

--- a/librabbitmq/amqp_socket.h
+++ b/librabbitmq/amqp_socket.h
@@ -180,7 +180,7 @@ int amqp_poll(int fd, int event, amqp_time_t deadline);
 int amqp_simple_wait_method_noblock(amqp_connection_state_t state,
                                     amqp_channel_t expected_channel,
                                     amqp_method_number_t expected_method,
-                                    struct timeval * timeout,
+                                    amqp_time_t deadline,
                                     amqp_method_t *output);
 
 amqp_rpc_reply_t

--- a/librabbitmq/amqp_socket.h
+++ b/librabbitmq/amqp_socket.h
@@ -189,7 +189,7 @@ AMQP_CALL amqp_simple_rpc_noblock(amqp_connection_state_t state,
                                   amqp_method_number_t request_id,
                                   amqp_method_number_t *expected_reply_ids,
                                   void *decoded_request_method,
-                                  struct timeval *timeout);
+                                  amqp_time_t deadline);
 
 void *
 amqp_simple_rpc_decoded_noblock(amqp_connection_state_t state,
@@ -197,13 +197,13 @@ amqp_simple_rpc_decoded_noblock(amqp_connection_state_t state,
                                 amqp_method_number_t request_id,
                                 amqp_method_number_t reply_id,
                                 void *decoded_request_method,
-                                struct timeval *timeout);
+                                amqp_time_t deadline);
 
 int amqp_send_method_inner(amqp_connection_state_t state,
                            amqp_channel_t channel,
                            amqp_method_number_t id,
                            void *decoded, int flags,
-                           struct timeval *timeout);
+                           amqp_time_t deadline);
 
 int
 amqp_queue_frame(amqp_connection_state_t state, amqp_frame_t *frame);

--- a/librabbitmq/amqp_socket.h
+++ b/librabbitmq/amqp_socket.h
@@ -177,86 +177,12 @@ int amqp_open_socket_inner(char const *hostname, int portnumber,
  * event (AMQP_SF_POLLIN, AMQP_SF_POLLOUT) */
 int amqp_poll(int fd, int event, amqp_time_t deadline);
 
-
-/**
- * Waits for a specific method from the broker with a timeout
- *
- * \warning You probably don't want to use this function. If this function
- *  doesn't receive exactly the frame requested it closes the whole connection.
- *
- * Waits for a single method on a channel from the broker.
- * If a frame is received that does not match expected_channel
- * or expected_method the program will abort
- *
- * \param [in] state the connection object
- * \param [in] expected_channel the channel that the method should be delivered on
- * \param [in] expected_method the method to wait for
- * \param [in] timeout a timeout to wait for a method. Passing in
- *             NULL will result in blocking behavior.
- * \param [out] output the method
- * \returns AMQP_STATUS_OK on success. An amqp_status_enum value is returned
- *  otherwise. Possible errors include:
- *  - AMQP_STATUS_WRONG_METHOD a frame containing the wrong method, wrong frame
- *    type or wrong channel was received. The connection is closed.
- *  - AMQP_STATUS_NO_MEMORY failure in allocating memory. The library is likely in
- *    an indeterminate state making recovery unlikely. Client should note the error
- *    and terminate the application
- *  - AMQP_STATUS_BAD_AMQP_DATA bad AMQP data was received. The connection
- *    should be shutdown immediately
- *  - AMQP_STATUS_UNKNOWN_METHOD: an unknown method was received from the
- *    broker. This is likely a protocol error and the connection should be
- *    shutdown immediately
- *  - AMQP_STATUS_UNKNOWN_CLASS: a properties frame with an unknown class
- *    was received from the broker. This is likely a protocol error and the
- *    connection should be shutdown immediately
- *  - AMQP_STATUS_HEARTBEAT_TIMEOUT timed out while waiting for heartbeat
- *    from the broker. The connection has been closed.
- *  - AMQP_STATUS_TIMEOUT the timeout was reached while waiting for a method.
- *  - AMQP_STATUS_TIMER_FAILURE system timer indicated failure.
- *  - AMQP_STATUS_SOCKET_ERROR a socket error occurred. The connection has
- *    been closed
- *  - AMQP_STATUS_SSL_ERROR a SSL socket error occurred. The connection has
- *    been closed.
- */
 int amqp_simple_wait_method_noblock(amqp_connection_state_t state,
                                     amqp_channel_t expected_channel,
                                     amqp_method_number_t expected_method,
                                     struct timeval * timeout,
                                     amqp_method_t *output);
 
-
-/**
- * Sends a method to the broker and waits for a method response
- *
- * \param [in] state the connection object
- * \param [in] channel the channel object
- * \param [in] request_id the method number of the request
- * \param [in] expected_reply_ids a 0 terminated array of expected response
- *             method numbers
- * \param [in] decoded_request_method the method to be sent to the broker
- * \param [in] timeout a timeout to wait for a RPC answer. Passing in
- *             NULL will result in blocking behavior.
- * \return a amqp_rpc_reply_t:
- *  - r.reply_type == AMQP_RESPONSE_NORMAL. RPC completed successfully
- *  - r.reply_type == AMQP_STATUS_TIMEOUT the timeout was reached while waiting
- *    for RPC answer.
- *  - r.reply_type == AMQP_RESPONSE_SERVER_EXCEPTION. The broker returned an
- *    exception:
- *    - If r.reply.id == AMQP_CHANNEL_CLOSE_METHOD a channel exception
- *      occurred, cast r.reply.decoded to amqp_channel_close_t* to see details
- *      of the exception. The client should amqp_send_method() a
- *      amqp_channel_close_ok_t. The channel must be re-opened before it
- *      can be used again. Any resources associated with the channel
- *      (auto-delete exchanges, auto-delete queues, consumers) are invalid
- *      and must be recreated before attempting to use them again.
- *    - If r.reply.id == AMQP_CONNECTION_CLOSE_METHOD a connection exception
- *      occurred, cast r.reply.decoded to amqp_connection_close_t* to see
- *      details of the exception. The client amqp_send_method() a
- *      amqp_connection_close_ok_t and disconnect from the broker.
- *  - r.reply_type == AMQP_RESPONSE_LIBRARY_EXCEPTION. An exception occurred
- *    within the library. Examine r.library_error and compare it against
- *    amqp_status_enum values to determine the error.
- */
 amqp_rpc_reply_t
 AMQP_CALL amqp_simple_rpc_noblock(amqp_connection_state_t state,
                                   amqp_channel_t channel,
@@ -265,21 +191,6 @@ AMQP_CALL amqp_simple_rpc_noblock(amqp_connection_state_t state,
                                   void *decoded_request_method,
                                   struct timeval *timeout);
 
-
-/**
- * Sends a method to the broker and waits for a method response
- *
- * \param [in] state the connection object
- * \param [in] channel the channel object
- * \param [in] request_id the method number of the request
- * \param [in] reply_id the method number expected in response
- * \param [in] decoded_request_method the request method
- * \param [in] timeout a timeout to wait for a RPC answer. Passing in
- *             NULL will result in blocking behavior.
- * \return a pointer to the method returned from the broker, or NULL on error.
- *  On error amqp_get_rpc_reply() will return an amqp_rpc_reply_t with
- *  details on the error that occurred.
- */
 void *
 amqp_simple_rpc_decoded_noblock(amqp_connection_state_t state,
                                 amqp_channel_t channel,

--- a/librabbitmq/amqp_socket.h
+++ b/librabbitmq/amqp_socket.h
@@ -199,11 +199,11 @@ amqp_simple_rpc_decoded_noblock(amqp_connection_state_t state,
                                 void *decoded_request_method,
                                 struct timeval *timeout);
 
-int amqp_send_method_inner_noblock(amqp_connection_state_t state,
-                                   amqp_channel_t channel,
-                                   amqp_method_number_t id,
-                                   void *decoded, int flags,
-                                   struct timeval *timeout);
+int amqp_send_method_inner(amqp_connection_state_t state,
+                           amqp_channel_t channel,
+                           amqp_method_number_t id,
+                           void *decoded, int flags,
+                           struct timeval *timeout);
 
 int
 amqp_queue_frame(amqp_connection_state_t state, amqp_frame_t *frame);


### PR DESCRIPTION
This is the reincarnation of pull request "Add timeout to amqp_login and amqp_login_with_properties".
I think I have a;so provide noblock version of amqp_send_method in amqp_login_inner

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/383)

<!-- Reviewable:end -->
