### PR TITLE
Fix link to rabbitmq-c-users link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This is a C-language AMQP client library for use with v2.0+ of the
 Announcements regarding the library are periodically made on the
 rabbitmq-c-users and cross-posted to rabbitmq-users.
 
- - <https://groups.google.com/forum/#!focum/rabbitmq-c-users>
+ - <https://groups.google.com/forum/#!forum/rabbitmq-c-users>
  - <https://groups.google.com/forum/#!forum/rabbitmq-users>
 
 ## Latest Stable Version


### PR DESCRIPTION
Fixes #388

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/389)
<!-- Reviewable:end -->
