### PR TITLE
Lib: Do not set MSG_MORE on last message header if no body follows

### DIFF
--- a/librabbitmq/amqp_api.c
+++ b/librabbitmq/amqp_api.c
@@ -183,6 +183,7 @@ int amqp_basic_publish(amqp_connection_state_t state,
   size_t body_offset;
   size_t usable_body_payload_size = state->frame_max - (HEADER_SIZE + FOOTER_SIZE);
   int res;
+  int flagz;
 
   amqp_basic_publish_t m;
   amqp_basic_properties_t default_properties;
@@ -224,7 +225,12 @@ int amqp_basic_publish(amqp_connection_state_t state,
   f.payload.properties.body_size = body.len;
   f.payload.properties.decoded = (void *) properties;
 
-  res = amqp_send_frame_inner(state, &f, AMQP_SF_MORE, amqp_time_infinite());
+  if (body.len > 0) {
+    flagz = AMQP_SF_MORE;
+  } else {
+    flagz = AMQP_SF_NONE;
+  }
+  res = amqp_send_frame_inner(state, &f, flagz, amqp_time_infinite());
   if (res < 0) {
     return res;
   }
@@ -232,7 +238,6 @@ int amqp_basic_publish(amqp_connection_state_t state,
   body_offset = 0;
   while (body_offset < body.len) {
     size_t remaining = body.len - body_offset;
-    int flagz;
 
     if (remaining == 0) {
       break;


### PR DESCRIPTION
Introduced with commit 2bc1f9b (lib: use MSG_MORE on Linux for
basic.publish), amqp_basic_publish() sets MSG_MORE on all but the
last send() syscall it triggers on the TCP socket to improve
performance. However, if no message body is provided, no completing
call without MSG_MORE follows, keeping the TCP packet pending.

On Linux, this may introduce a message send delay, until the kernel
sends out the data anyway after 200ms. This may add a significant
delay if a consumer is waiting for such an empty (confirmation)
message.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/410)
<!-- Reviewable:end -->
