### PR TITLE
TCP Keep alive for RabbitMQ Client

### DIFF
--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -480,6 +480,11 @@ int amqp_open_socket_inner(char const *hostname,
       continue;
     }
 
+    if (0 != amqp_os_socket_setsockopt(sockfd, SOL_SOCKET, SO_KEEPALIVE, &one, sizeof(one))) {
+      last_error = AMQP_STATUS_SOCKET_ERROR;
+      continue;
+    }
+
 #ifdef _WIN32
     res = connect(sockfd, addr->ai_addr, (int)addr->ai_addrlen);
 #else


### PR DESCRIPTION
- Enable TCP Keep Alive for rabbitmq client
- Helps in cases when the connection is conntracked or there is NAT
  in between

Fixes #411

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/412)
<!-- Reviewable:end -->
