### PR TITLE
autotools: Fix linker errors when SSL is enabled

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -49,6 +49,9 @@ librabbitmq_librabbitmq_la_SOURCES += \
   librabbitmq/amqp_openssl_bio.h \
   librabbitmq/amqp_openssl_hostname_validation.c \
   librabbitmq/amqp_openssl_hostname_validation.h
+
+librabbitmq_librabbitmq_la_LDFLAGS += -pthread
+
 if OS_APPLE
 librabbitmq_librabbitmq_la_CFLAGS += -Wno-deprecated-declarations
 endif


### PR DESCRIPTION
e.g., `librabbitmq/.libs/librabbitmq.so: undefined reference to 'pthread_once'`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/415)
<!-- Reviewable:end -->
