### PR TITLE
Compiling issue with autotools, clang -Werror.

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -91,6 +91,8 @@ AS_IF([test "x$os_win32" = xyes],
 #  Solaris needs -lsocket -lnsl
 #  QNX will need -lsocket
 
+saved_CFLAGS=$CFLAGS
+CFLAGS=
 AC_SEARCH_LIBS([getaddrinfo], [socket], [],
                [AC_CHECK_LIB([getaddrinfo], [socket],
                              [LIBS="-lsocket -lnsl $LIBS"],
@@ -188,6 +190,7 @@ AC_CONFIG_FILES([
     librabbitmq.pc
     Makefile
 ])
+CFLAGS=$saved_CFLAGS
 AC_OUTPUT
 AC_MSG_RESULT([
 $PACKAGE_NAME build options:

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -1494,7 +1494,7 @@ amqp_rpc_reply_t amqp_login(amqp_connection_state_t state,
                             int channel_max,
                             int frame_max,
                             int heartbeat,
-                            amqp_sasl_method_enum sasl_method,
+                            int sasl_method,
                             ...)
 {
   va_list vl;
@@ -1517,7 +1517,7 @@ amqp_rpc_reply_t amqp_login_with_properties(amqp_connection_state_t state,
     int frame_max,
     int heartbeat,
     const amqp_table_t *client_properties,
-    amqp_sasl_method_enum sasl_method,
+    int sasl_method,
     ...)
 {
   va_list vl;


### PR DESCRIPTION
Autotools configure steps fails, when clang is used with -Werror option.

autoreconf (GNU Autoconf) 2.69
clang version 4.0.0-1ubuntu1 (tags/RELEASE_400/rc1)

More details:
The `AC_SEARCH_LIBS` creates a dummy function definition, with empty argument list, but in clang it is a warning unless void is given as parameter.

Signed-off-by: kokan <peter.kokai@balabit.com>

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/439)
<!-- Reviewable:end -->
