### PR TITLE
Added coverage measurements using gcov and publish to coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ env:
    #   via the "travis encrypt" command using the project repo's public key
    - secure: "gDwqo3jHj+HHGzFKnxL/nwZhbVeh2pItw0TbeaHcLtWubUZaf85ViEQRaXPyfnbG7l0OEQq+PjyhKAfvViVq2NP0lGeeu4VM5uMZJhsCLN594BJr39Y4XzOapg0O8mEMhQ0DU2u1Zo4LMgEcRz67aosVQOj6QV30tOzp9fnxn9U="
 
+services:
+  - rabbitmq
+  
 matrix:
   include:
     # Note that the first compiler in the matrix must be gcc, so that the

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,9 @@ matrix:
     - compiler: gcc
       os: linux
       env: CONFIG=cmake
+    - compiler: gcc
+      os: linux
+      env: CONFIG=coverage
     - compiler: clang
       os: linux
       env: CONFIG=cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,30 +140,6 @@ else()
   endif()
 endif()
 
-# Add new build types
-message("* Adding coverage build type...")
-SET(CMAKE_CXX_FLAGS_COVERAGE
-    "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage"
-    CACHE STRING "Flags used by the C++ compiler during coverage builds."
-    FORCE )
-SET(CMAKE_C_FLAGS_COVERAGE
-    "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage"
-    CACHE STRING "Flags used by the C compiler during coverage builds."
-    FORCE )
-SET(CMAKE_EXE_LINKER_FLAGS_COVERAGE
-    ""
-    CACHE STRING "Flags used for linking binaries during coverage builds."
-    FORCE )
-SET(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
-    ""
-    CACHE STRING "Flags used by the shared libraries linker during coverage builds."
-    FORCE )
-MARK_AS_ADVANCED(
-    CMAKE_CXX_FLAGS_COVERAGE
-    CMAKE_C_FLAGS_COVERAGE
-    CMAKE_EXE_LINKER_FLAGS_COVERAGE
-    CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
-
 option(REGENERATE_AMQP_FRAMING "Regenerate amqp_framing.h/amqp_framing.c sources (for developer use)" OFF)
 mark_as_advanced(REGENERATE_AMQP_FRAMING)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -140,6 +140,30 @@ else()
   endif()
 endif()
 
+# Add new build types
+message("* Adding coverage build type...")
+SET(CMAKE_CXX_FLAGS_COVERAGE
+    "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage"
+    CACHE STRING "Flags used by the C++ compiler during coverage builds."
+    FORCE )
+SET(CMAKE_C_FLAGS_COVERAGE
+    "${CMAKE_C_FLAGS} -fprofile-arcs -ftest-coverage"
+    CACHE STRING "Flags used by the C compiler during coverage builds."
+    FORCE )
+SET(CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    ""
+    CACHE STRING "Flags used for linking binaries during coverage builds."
+    FORCE )
+SET(CMAKE_SHARED_LINKER_FLAGS_COVERAGE
+    ""
+    CACHE STRING "Flags used by the shared libraries linker during coverage builds."
+    FORCE )
+MARK_AS_ADVANCED(
+    CMAKE_CXX_FLAGS_COVERAGE
+    CMAKE_C_FLAGS_COVERAGE
+    CMAKE_EXE_LINKER_FLAGS_COVERAGE
+    CMAKE_SHARED_LINKER_FLAGS_COVERAGE )
+
 option(REGENERATE_AMQP_FRAMING "Regenerate amqp_framing.h/amqp_framing.c sources (for developer use)" OFF)
 mark_as_advanced(REGENERATE_AMQP_FRAMING)
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://secure.travis-ci.org/alanxz/rabbitmq-c.png?branch=master)](http://travis-ci.org/alanxz/rabbitmq-c)
 
+[![Coverage Status](https://coveralls.io/repos/github/alanxz/rabbitmq-c/badge.svg?branch=master)](https://coveralls.io/github/alanxz/rabbitmq-c?branch=master)
+
 ## Introduction
 
 This is a C-language AMQP client library for use with v2.0+ of the

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,7 +33,10 @@ add_test(status_enum test_status_enum)
 add_executable(test_basic
                test_basic.c)
 target_link_libraries(test_basic rabbitmq-static)
-add_test(basic test_basic)
+
+if (NOT APPLE)
+  add_test(basic test_basic)
+endif()
 
 add_executable(test_sasl_mechanism test_sasl_mechanism.c)
 target_link_libraries(test_sasl_mechanism rabbitmq-static)
@@ -42,3 +45,4 @@ add_test(sasl_mechanism test_sasl_mechanism)
 add_executable(test_merge_capabilities test_merge_capabilities.c)
 target_link_libraries(test_merge_capabilities rabbitmq-static)
 add_test(merge_capabilities test_merge_capabilities)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -30,6 +30,11 @@ add_executable(test_status_enum
 target_link_libraries(test_status_enum rabbitmq-static)
 add_test(status_enum test_status_enum)
 
+add_executable(test_basic
+               test_basic.c)
+target_link_libraries(test_basic rabbitmq-static)
+add_test(basic test_basic)
+
 add_executable(test_sasl_mechanism test_sasl_mechanism.c)
 target_link_libraries(test_sasl_mechanism rabbitmq-static)
 add_test(sasl_mechanism test_sasl_mechanism)

--- a/tests/test_basic.c
+++ b/tests/test_basic.c
@@ -1,0 +1,231 @@
+/* vim:set ft=c ts=2 sw=2 sts=2 et cindent: */
+/*
+ * Copyright 2017 Simon Giesecke
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use, copy,
+ * modify, merge, publish, distribute, sublicense, and/or sell copies
+ * of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+ * BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ * ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "amqp.h"
+#include "amqp_tcp_socket.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef _WIN32
+#include <WinSock2.h>
+#else
+#include <sys/time.h>
+#endif
+
+#define assert(x)                                    \
+  {                                                  \
+    if (!(x)) {                                      \
+      fprintf(stderr, "Assertion failed: %s\n", #x); \
+      abort();                                       \
+    }                                                \
+  }
+
+static const int fixed_channel_id = 1;
+static const char test_queue_name[] = "test_queue";
+
+amqp_connection_state_t setup_connection_and_channel(void) {
+  amqp_connection_state_t connection_state_ = amqp_new_connection();
+
+  amqp_socket_t *socket = amqp_tcp_socket_new(connection_state_);
+  assert(socket);
+
+  int rc = amqp_socket_open(socket, "localhost", AMQP_PROTOCOL_PORT);
+  assert(rc == AMQP_STATUS_OK);
+
+  amqp_rpc_reply_t rpc_reply = amqp_login_with_properties(
+      connection_state_, "/", 1, AMQP_DEFAULT_FRAME_SIZE, 0, NULL,
+      AMQP_SASL_METHOD_PLAIN, "guest", "guest");
+  assert(rpc_reply.reply_type == AMQP_RESPONSE_NORMAL);
+
+  amqp_channel_open_ok_t *res =
+      amqp_channel_open(connection_state_, fixed_channel_id);
+  assert(res != NULL);
+
+  return connection_state_;
+}
+
+void close_channel_and_connection(amqp_connection_state_t connection_state_) {
+  amqp_rpc_reply_t rpc_reply =
+      amqp_channel_close(connection_state_, 1, AMQP_REPLY_SUCCESS);
+  assert(rpc_reply.reply_type == AMQP_RESPONSE_NORMAL);
+
+  rpc_reply = amqp_connection_close(connection_state_, AMQP_REPLY_SUCCESS);
+  assert(rpc_reply.reply_type == AMQP_RESPONSE_NORMAL);
+
+  int rc = amqp_destroy_connection(connection_state_);
+  assert(rc == AMQP_STATUS_OK);
+}
+
+void basic_publish(amqp_connection_state_t connectionState_,
+                   const char *message_) {
+  amqp_bytes_t message_bytes = amqp_cstring_bytes(message_);
+
+  amqp_basic_properties_t properties;
+  properties._flags = 0;
+
+  properties._flags |= AMQP_BASIC_DELIVERY_MODE_FLAG;
+  properties.delivery_mode = AMQP_DELIVERY_NONPERSISTENT;
+
+  int retval = amqp_basic_publish(
+      connectionState_, fixed_channel_id, amqp_cstring_bytes(""),
+      amqp_cstring_bytes(test_queue_name),
+      /* mandatory=*/1,
+      /* immediate=*/0,  /* RabbitMQ 3.x does not support the "immediate" flag
+                           according to
+                           https://www.rabbitmq.com/specification.html */
+      &properties, message_bytes);
+
+  assert(retval == 0);
+}
+
+void queue_declare(amqp_connection_state_t connection_state_,
+                   const char *queue_name_) {
+  amqp_queue_declare_ok_t *res = amqp_queue_declare(
+      connection_state_, fixed_channel_id, amqp_cstring_bytes(queue_name_),
+      /*passive*/ 0,
+      /*durable*/ 0,
+      /*exclusive*/ 0,
+      /*auto_delete*/ 1, amqp_empty_table);
+  assert(res != NULL);
+}
+
+void receive_body_frames(amqp_connection_state_t connection_state_,
+                         char *body_, uint64_t body_size_) {
+  char *body_begin = body_;
+  uint64_t body_read, body_left;
+  for (body_read = 0, body_left = body_size_; body_read < body_size_;) {
+    amqp_frame_t body_frame;
+    int rc = amqp_simple_wait_frame(connection_state_, &body_frame);
+    assert(rc == AMQP_STATUS_OK);
+
+    assert(body_frame.frame_type == AMQP_FRAME_BODY);
+
+    amqp_bytes_t *body_fragment = &body_frame.payload.body_fragment;
+
+    assert(body_fragment->len <= body_left);
+
+    memcpy(body_begin + body_read, body_fragment->bytes, body_fragment->len);
+    body_read += body_fragment->len;
+    body_left -= body_fragment->len;
+  }
+}
+
+char *basic_get(amqp_connection_state_t connection_state_,
+                const char *queue_name_, uint64_t *out_body_size_) {
+  amqp_rpc_reply_t rpc_reply;
+  do {
+    rpc_reply = amqp_basic_get(connection_state_, fixed_channel_id,
+                               amqp_cstring_bytes(queue_name_), /*no_ack*/ 1);
+  } while (rpc_reply.reply_type == AMQP_RESPONSE_NORMAL &&
+           rpc_reply.reply.id == AMQP_BASIC_GET_EMPTY_METHOD);
+
+  assert(rpc_reply.reply.id == AMQP_BASIC_GET_OK_METHOD);
+
+  amqp_frame_t header_frame;
+  int rc = amqp_simple_wait_frame(connection_state_, &header_frame);
+  assert(rc == AMQP_STATUS_OK);
+
+  assert(header_frame.frame_type == AMQP_FRAME_HEADER);
+
+  *out_body_size_ = header_frame.payload.properties.body_size;
+
+  /* message body cannot be from the pool, body is freed in envelope_destroy
+     with amqp_bytes_free */
+  char *body = malloc(*out_body_size_);
+  if (*out_body_size_) {
+    receive_body_frames(connection_state_, body, *out_body_size_);
+  }
+  return body;
+}
+
+void publish_and_basic_get_message(const char *msg_to_publish) {
+  amqp_connection_state_t connection_state = setup_connection_and_channel();
+
+  queue_declare(connection_state, test_queue_name);
+  basic_publish(connection_state, msg_to_publish);
+
+  uint64_t body_size;
+  char *msg = basic_get(connection_state, test_queue_name, &body_size);
+
+  assert(body_size == strlen(msg_to_publish));
+  assert(strncmp(msg_to_publish, msg, body_size) == 0);
+  free(msg);
+
+  close_channel_and_connection(connection_state);
+}
+
+char *consume_message(amqp_connection_state_t connection_state_,
+                      const char *queue_name_, uint64_t *out_body_size_) {
+  amqp_basic_consume_ok_t *result =
+      amqp_basic_consume(connection_state_, fixed_channel_id,
+                         amqp_cstring_bytes(queue_name_), amqp_empty_bytes,
+                         /*no_local*/ 0,
+                         /*no_ack*/ 1,
+                         /*exclusive*/ 0, amqp_empty_table);
+  assert(result != NULL);
+
+  amqp_envelope_t envelope;
+  struct timeval timeout = {0, 250};
+  amqp_rpc_reply_t rpc_reply =
+      amqp_consume_message(connection_state_, &envelope, &timeout, 0);
+  assert(rpc_reply.reply_type == AMQP_RESPONSE_NORMAL);
+
+  *out_body_size_ = envelope.message.body.len;
+  char *body = malloc(*out_body_size_);
+  if (*out_body_size_) {
+    memcpy(body, envelope.message.body.bytes, *out_body_size_);
+  }
+
+  amqp_destroy_envelope(&envelope);
+  return body;
+}
+
+void publish_and_consume_message(const char *msg_to_publish) {
+  amqp_connection_state_t connection_state = setup_connection_and_channel();
+
+  queue_declare(connection_state, test_queue_name);
+  basic_publish(connection_state, msg_to_publish);
+
+  uint64_t body_size;
+  char *msg = consume_message(connection_state, test_queue_name, &body_size);
+
+  assert(body_size == strlen(msg_to_publish));
+  assert(strncmp(msg_to_publish, msg, body_size) == 0);
+  free(msg);
+
+  close_channel_and_connection(connection_state);
+}
+
+int main(void) {
+  publish_and_basic_get_message("");
+  publish_and_basic_get_message("TEST");
+
+  publish_and_consume_message("");
+  publish_and_consume_message("TEST");
+
+  return 0;
+}

--- a/tests/test_basic.c
+++ b/tests/test_basic.c
@@ -36,13 +36,10 @@
 #include <sys/time.h>
 #endif
 
-#define assert(x)                                    \
-  {                                                  \
-    if (!(x)) {                                      \
-      fprintf(stderr, "Assertion failed: %s\n", #x); \
-      abort();                                       \
-    }                                                \
-  }
+#ifdef NDEBUG
+# undef NDEBUG
+#endif
+#include <assert.h>
 
 static const int fixed_channel_id = 1;
 static const char test_queue_name[] = "test_queue";

--- a/tests/test_basic.c
+++ b/tests/test_basic.c
@@ -65,12 +65,8 @@ amqp_connection_state_t setup_connection_and_channel(void) {
   return connection_state_;
 }
 
-void close_channel_and_connection(amqp_connection_state_t connection_state_) {
-  amqp_rpc_reply_t rpc_reply =
-      amqp_channel_close(connection_state_, 1, AMQP_REPLY_SUCCESS);
-  assert(rpc_reply.reply_type == AMQP_RESPONSE_NORMAL);
-
-  rpc_reply = amqp_connection_close(connection_state_, AMQP_REPLY_SUCCESS);
+void close_and_destroy_connection(amqp_connection_state_t connection_state_) {
+  amqp_rpc_reply_t rpc_reply = amqp_connection_close(connection_state_, AMQP_REPLY_SUCCESS);
   assert(rpc_reply.reply_type == AMQP_RESPONSE_NORMAL);
 
   int rc = amqp_destroy_connection(connection_state_);
@@ -172,7 +168,7 @@ void publish_and_basic_get_message(const char *msg_to_publish) {
   assert(strncmp(msg_to_publish, msg, body_size) == 0);
   free(msg);
 
-  close_channel_and_connection(connection_state);
+  close_and_destroy_connection(connection_state);
 }
 
 char *consume_message(amqp_connection_state_t connection_state_,
@@ -214,7 +210,7 @@ void publish_and_consume_message(const char *msg_to_publish) {
   assert(strncmp(msg_to_publish, msg, body_size) == 0);
   free(msg);
 
-  close_channel_and_connection(connection_state);
+  close_and_destroy_connection(connection_state);
 }
 
 int main(void) {

--- a/tests/test_basic.c
+++ b/tests/test_basic.c
@@ -53,8 +53,8 @@ amqp_connection_state_t setup_connection_and_channel(void) {
   int rc = amqp_socket_open(socket, "localhost", AMQP_PROTOCOL_PORT);
   assert(rc == AMQP_STATUS_OK);
 
-  amqp_rpc_reply_t rpc_reply = amqp_login_with_properties(
-      connection_state_, "/", 1, AMQP_DEFAULT_FRAME_SIZE, 0, NULL,
+  amqp_rpc_reply_t rpc_reply = amqp_login(
+      connection_state_, "/", 1, AMQP_DEFAULT_FRAME_SIZE, AMQP_DEFAULT_HEARTBEAT,
       AMQP_SASL_METHOD_PLAIN, "guest", "guest");
   assert(rpc_reply.reply_type == AMQP_RESPONSE_NORMAL);
 

--- a/tests/test_basic.c
+++ b/tests/test_basic.c
@@ -156,7 +156,7 @@ char *consume_message(amqp_connection_state_t connection_state_,
   assert(result != NULL);
 
   amqp_envelope_t envelope;
-  struct timeval timeout = {0, 250};
+  struct timeval timeout = {0, 500};
   amqp_rpc_reply_t rpc_reply =
       amqp_consume_message(connection_state_, &envelope, &timeout, 0);
   assert(rpc_reply.reply_type == AMQP_RESPONSE_NORMAL);

--- a/travis.sh
+++ b/travis.sh
@@ -8,6 +8,17 @@ build_cmake() {
   ctest -V .
 }
 
+build_coverage() {
+  mkdir $PWD/_build && cd $PWD/_build
+  cmake .. -DCMAKE_BUILD_TYPE=Coverage -DCMAKE_INSTALL_PREFIX=$PWD/../_install -DCMAKE_C_FLAGS="-Werror" \
+    ${_CMAKE_OPENSSL_FLAG}
+  cmake --build . --target install
+  ctest -V .
+  
+  pip install --user cpp-coveralls
+  coveralls --exclude tests --build-root . --root .. --gcov-options '\-lp'
+}
+
 build_asan() {
   mkdir $PWD/_build && cd $PWD/_build
   cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=$PWD/../_install \

--- a/travis.sh
+++ b/travis.sh
@@ -10,7 +10,8 @@ build_cmake() {
 
 build_coverage() {
   mkdir $PWD/_build && cd $PWD/_build
-  cmake .. -DCMAKE_BUILD_TYPE=Coverage -DCMAKE_INSTALL_PREFIX=$PWD/../_install -DCMAKE_C_FLAGS="-Werror" \
+  cmake .. -DCMAKE_BUILD_TYPE=Coverage -DCMAKE_INSTALL_PREFIX=$PWD/../_install \
+    -DCMAKE_C_FLAGS="-Werror -fprofile-arcs -ftest-coverage" \
     ${_CMAKE_OPENSSL_FLAG}
   cmake --build . --target install
   ctest -V .


### PR DESCRIPTION
I also added some basic tests using a broker.

You can see exemplary results under https://coveralls.io/github/sigiesec/rabbitmq-c?branch=zero-length-message

@alanxz For this to work, you need to enable coveralls for the alanxz/rabbitmq-c project and set the COVERALLS_REPO_TOKEN environment variable in the travis-ci project.

There is one open issue with this PR: On Mac OS X, the newly added test fails, probably because `services: rabbitmq` in the travis.yml has no effect on Mac OS X. A rabbitmq broker needs to be installed and started manually there.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/443)
<!-- Reviewable:end -->
#