### PR TITLE
OpenSSL should require an explicit un-initialization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.6)
+cmake_minimum_required(VERSION 2.8.12)
 project(rabbitmq-c "C")
 
 # Enable MACOSX_RPATH by default. See: cmake --help-policy CMP0042
@@ -114,6 +114,17 @@ check_library_exists(rt clock_gettime "time.h" CLOCK_GETTIME_NEEDS_LIBRT)
 check_library_exists(rt posix_spawnp "spawn.h" POSIX_SPAWNP_NEEDS_LIBRT)
 if (CLOCK_GETTIME_NEEDS_LIBRT OR POSIX_SPAWNP_NEEDS_LIBRT)
   set(LIBRT rt)
+endif()
+
+option(ENABLE_SSL_SUPPORT "Enable SSL support" ON)
+
+if (ENABLE_SSL_SUPPORT)
+  find_package(OpenSSL 0.9.8 REQUIRED)
+
+  cmake_push_check_state()
+  set(THREADS_PREFER_PTHREAD_FLAG ON)
+  find_package(Threads REQUIRED)
+  cmake_pop_check_state()
 endif()
 
 if (MSVC)
@@ -246,7 +257,6 @@ if (POPT_FOUND AND XmlTo_FOUND)
   set(DO_DOCS ON)
 endif()
 
-find_package(Threads)
 
 option(BUILD_SHARED_LIBS "Build rabbitmq-c as a shared library" ON)
 option(BUILD_STATIC_LIBS "Build rabbitmq-c as a static library" ON)
@@ -256,12 +266,6 @@ option(BUILD_TOOLS "Build Tools (requires POPT Library)" ${POPT_FOUND})
 option(BUILD_TOOLS_DOCS "Build man pages for Tools (requires xmlto)" ${DO_DOCS})
 option(BUILD_TESTS "Build tests (run tests with make test)" ON)
 option(BUILD_API_DOCS "Build Doxygen API docs" ${DOXYGEN_FOUND})
-option(ENABLE_SSL_SUPPORT "Enable SSL support" ON)
-option(ENABLE_THREAD_SAFETY "Enable thread safety when using OpenSSL" ${Threads_FOUND})
-
-if (ENABLE_SSL_SUPPORT)
-  find_package(OpenSSL 0.9.8 REQUIRED)
-endif()
 
 if (NOT BUILD_SHARED_LIBS AND NOT BUILD_STATIC_LIBS)
     message(FATAL_ERROR "One or both of BUILD_SHARED_LIBS or BUILD_STATIC_LIBS must be set to ON to build")
@@ -309,12 +313,8 @@ endif ()
 
 set(libs_private ${SOCKET_LIBRARIES} ${LIBRT})
 if (ENABLE_SSL_SUPPORT)
-  if (SSL_ENGINE STREQUAL "OpenSSL")
-    set(requires_private "openssl")
-  endif()
-  if (ENABLE_THREAD_SAFETY)
-    set(libs_private ${libs_private} ${CMAKE_THREAD_LIBS_INIT})
-  endif()
+  set(requires_private "openssl")
+  set(libs_private ${libs_private} ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
 set(prefix ${CMAKE_INSTALL_PREFIX})

--- a/README.md
+++ b/README.md
@@ -82,8 +82,6 @@ Other interesting flags that can be passed to CMake:
    find the XmlTo utility.
 * `ENABLE_SSL_SUPPORT=ON/OFF` toggles building rabbitmq-c with SSL support. By
    default this is ON if the OpenSSL headers and library can be found.
-* `ENABLE_THREAD_SAFETY=ON/OFF` toggles OpenSSL thread-safety. By default this
-   is ON
 * `BUILD_API_DOCS=ON/OFF` - toggles building the Doxygen API documentation, by
    default this is OFF
 

--- a/librabbitmq/CMakeLists.txt
+++ b/librabbitmq/CMakeLists.txt
@@ -96,13 +96,10 @@ if (ENABLE_SSL_SUPPORT)
       PROPERTIES COMPILE_FLAGS -Wno-deprecated-declarations)
   endif()
 
-  if (ENABLE_THREAD_SAFETY)
-    add_definitions(-DENABLE_THREAD_SAFETY)
-    if (WIN32)
-      set(AMQP_SSL_SRCS ${AMQP_SSL_SRCS} win32/threads.h win32/threads.c)
-    else()
-      set(AMQP_SSL_SRCS ${AMQP_SSL_SRCS} unix/threads.h)
-    endif()
+  if (WIN32)
+    set(AMQP_SSL_SRCS ${AMQP_SSL_SRCS} win32/threads.h win32/threads.c)
+  else()
+    set(AMQP_SSL_SRCS ${AMQP_SSL_SRCS} unix/threads.h)
   endif()
 endif()
 
@@ -122,6 +119,9 @@ set(RMQ_LIBRARIES ${AMQP_SSL_LIBS} ${SOCKET_LIBRARIES} ${LIBRT} ${CMAKE_THREAD_L
 
 if (BUILD_SHARED_LIBS)
     add_library(rabbitmq SHARED ${RABBITMQ_SOURCES})
+    if (THREADS_HAVE_PTHREAD_ARG)
+      target_compile_options(rabbitmq PUBLIC "-pthread")
+    endif()
 
     target_link_libraries(rabbitmq ${RMQ_LIBRARIES})
 
@@ -142,6 +142,9 @@ endif (BUILD_SHARED_LIBS)
 
 if (BUILD_STATIC_LIBS)
     add_library(rabbitmq-static STATIC ${RABBITMQ_SOURCES})
+    if (THREADS_HAVE_PTHREAD_ARG)
+      target_compile_options(rabbitmq-static PUBLIC "-pthread")
+    endif()
 
     target_link_libraries(rabbitmq-static ${RMQ_LIBRARIES})
 
@@ -150,14 +153,14 @@ if (BUILD_STATIC_LIBS)
         set_target_properties(rabbitmq-static PROPERTIES
           VERSION ${RMQ_VERSION}
           OUTPUT_NAME librabbitmq.${RMQ_SOVERSION})
-        
+
         if(MSVC)
             set_target_properties(rabbitmq-static PROPERTIES
             # Embed debugging info in the library itself instead of generating
             # a .pdb file.
             COMPILE_OPTIONS "/Z7")
         endif(MSVC)
-        
+
     else (WIN32)
         set_target_properties(rabbitmq-static PROPERTIES VERSION ${RMQ_VERSION} SOVERSION ${RMQ_SOVERSION} OUTPUT_NAME rabbitmq)
     endif (WIN32)

--- a/librabbitmq/amqp_openssl_bio.c
+++ b/librabbitmq/amqp_openssl_bio.c
@@ -42,9 +42,7 @@
 
 #ifdef AMQP_USE_AMQP_BIO
 
-#ifdef ENABLE_THREAD_SAFETY
 static pthread_once_t bio_init_once = PTHREAD_ONCE_INIT;
-#endif
 
 static int bio_initialized = 0;
 static BIO_METHOD amqp_bio_method;
@@ -150,11 +148,7 @@ static void amqp_openssl_bio_init(void) {
 BIO_METHOD *amqp_openssl_bio(void) {
 #ifdef AMQP_USE_AMQP_BIO
   if (!bio_initialized) {
-#ifdef ENABLE_THREAD_SAFETY
     pthread_once(&bio_init_once, amqp_openssl_bio_init);
-#else
-    amqp_openssl_bio_init();
-#endif /* ifndef ENABLE_THREAD_SAFETY */
   }
 
   return &amqp_bio_method;

--- a/librabbitmq/amqp_openssl_bio.h
+++ b/librabbitmq/amqp_openssl_bio.h
@@ -25,6 +25,8 @@
 
 #include <openssl/bio.h>
 
+void amqp_openssl_bio_init(void);
+
 BIO_METHOD* amqp_openssl_bio(void);
 
 #endif /* ifndef AMQP_OPENSSL_BIO */

--- a/librabbitmq/amqp_ssl_socket.h
+++ b/librabbitmq/amqp_ssl_socket.h
@@ -181,19 +181,18 @@ int AMQP_CALL amqp_ssl_socket_set_ssl_versions(amqp_socket_t *self,
                                                amqp_tls_version_t max);
 
 /**
- * Sets whether rabbitmq-c initializes the underlying SSL library.
+ * Sets whether rabbitmq-c will initialize OpenSSL.
  *
- * For SSL libraries that require a one-time initialization across
- * a whole program (e.g., OpenSSL) this sets whether or not rabbitmq-c
- * will initialize the SSL library when the first call to
- * amqp_open_socket() is made. You should call this function with
+ * OpenSSL requires a one-time initialization across a whole program, this sets
+ * whether or not rabbitmq-c will initialize the SSL library when the first call
+ * to amqp_ssl_socket_new() is made. You should call this function with
  * do_init = 0 if the underlying SSL library is initialized somewhere else
  * the program.
  *
  * Failing to initialize or double initialization of the SSL library will
  * result in undefined behavior
  *
- * By default rabbitmq-c will initialize the underlying SSL library
+ * By default rabbitmq-c will initialize the underlying SSL library.
  *
  * NOTE: calling this function after the first socket has been opened with
  * amqp_open_socket() will not have any effect.
@@ -206,6 +205,34 @@ int AMQP_CALL amqp_ssl_socket_set_ssl_versions(amqp_socket_t *self,
  */
 AMQP_PUBLIC_FUNCTION
 void AMQP_CALL amqp_set_initialize_ssl_library(amqp_boolean_t do_initialize);
+
+/**
+ * Initialize the underlying SSL/TLS library.
+ *
+ * The OpenSSL library requires a one-time initialization across the whole
+ * program.
+ *
+ * This function unconditionally initializes OpenSSL so that rabbitmq-c may
+ * use it.
+ *
+ * This function is thread-safe, and may be called more than once.
+ *
+ * \return AMQP_STATUS_OK on success.
+ *
+ * \since v0.9.0
+ */
+AMQP_PUBLIC_FUNCTION
+int AMQP_CALL amqp_initialize_ssl_library(void);
+
+/**
+ * Uninitialize the underlying SSL/TLS library.
+ *
+ * \return AMQP_STATUS_OK on success.
+ *
+ * \since v0.9.0
+ */
+AMQP_PUBLIC_FUNCTION
+int AMQP_CALL amqp_uninitialize_ssl_library(void);
 
 AMQP_END_DECLS
 

--- a/librabbitmq/win32/threads.c
+++ b/librabbitmq/win32/threads.c
@@ -49,3 +49,8 @@ int pthread_mutex_unlock(pthread_mutex_t *mutex) {
   ReleaseSRWLockExclusive(mutex);
   return 0;
 }
+
+int pthread_mutex_destroy(pthread_mutex_t *mutex) {
+  /* SRW's do not require destruction. */
+  return 0;
+}

--- a/librabbitmq/win32/threads.h
+++ b/librabbitmq/win32/threads.h
@@ -44,5 +44,6 @@ DWORD pthread_self(void);
 int pthread_mutex_init(pthread_mutex_t *, void *attr);
 int pthread_mutex_lock(pthread_mutex_t *);
 int pthread_mutex_unlock(pthread_mutex_t *);
+int pthread_mutex_destroy(pthread_mutex_t *);
 
 #endif /* AMQP_THREAD_H */


### PR DESCRIPTION
Underlying OpenSSL library will only be un-initialized when `amqp_uninitialize_ssl_library` is called, instead of when the connection count drops to 0.

Fixes #444

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/465)
<!-- Reviewable:end -->
