### PR TITLE
Add ability to use locks for heartbeats managed inside the library

### DIFF
--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -783,7 +783,7 @@ typedef enum {
 
 /**
  * Method prototype for external heart beat management.
- * Use this prototype to create an application level method called each time a 
+ * Use this prototype to create an application level method called each time a
  * heart beat has to be sent to broker.
  * This allows to manage thread safety at application level.
  *
@@ -806,12 +806,13 @@ typedef enum {
  *
  * \since v0.8.1
  */
-typedef int (*amqp_send_heartbeat_ex_t)(amqp_connection_state_t state, void *context);
+typedef int (*amqp_send_heartbeat_ex_t)(amqp_connection_state_t state,
+                                        void *context);
 
 /**
  * Method prototype for external heart beat management.
- * Use this prototype to create an application level method called each time a heart 
- * beat is received from broker.
+ * Use this prototype to create an application level method called each time a
+ * heart beat is received from broker.
  * This allows to manage thread safety at application level.
  *
  * \param [in] context the application level context pointer
@@ -1082,7 +1083,8 @@ amqp_connection_state_t AMQP_CALL amqp_new_connection(void);
  * \param [in] state the connection object
  * \param [in] send_func the send method pointer
  * \param [in] recv_func the on receive method pointer
- * \param [in] context the pointer to an optional application context (not used internally)
+ * \param [in] context pointer to an optional application context (not used
+ * internally)
  * \return AMQP_STATUS_OK on success, an amqp_status_enum value otherwise.
  *
  * \sa amp_send_heartbeat_ex_t
@@ -1091,9 +1093,9 @@ amqp_connection_state_t AMQP_CALL amqp_new_connection(void);
  * \since v0.8.1
  */
 AMQP_PUBLIC_FUNCTION
-void AMQP_CALL amqp_set_heartbeat_ex(amqp_connection_state_t state, 
-                                     amqp_send_heartbeat_ex_t send_func, 
-                                     amqp_on_receive_heartbeat_t recv_func, 
+void AMQP_CALL amqp_set_heartbeat_ex(amqp_connection_state_t state,
+                                     amqp_send_heartbeat_ex_t send_func,
+                                     amqp_on_receive_heartbeat_t recv_func,
                                      void *context);
 
 /**

--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -783,7 +783,8 @@ typedef enum {
 
 /**
  * Method prototype for external heart beat management.
- * Use this prototype to create an application level method called each time a heart beat has to be sent to broker.
+ * Use this prototype to create an application level method called each time a 
+ * heart beat has to be sent to broker.
  * This allows to manage thread safety at application level.
  *
  * sample :
@@ -809,7 +810,8 @@ typedef int (*amqp_send_heartbeat_ex_t)(amqp_connection_state_t state, void *con
 
 /**
  * Method prototype for external heart beat management.
- * Use this prototype to create an application level method called each time a heart beat is received from broker.
+ * Use this prototype to create an application level method called each time a heart 
+ * beat is received from broker.
  * This allows to manage thread safety at application level.
  *
  * \param [in] context the application level context pointer
@@ -1089,8 +1091,10 @@ amqp_connection_state_t AMQP_CALL amqp_new_connection(void);
  * \since v0.8.1
  */
 AMQP_PUBLIC_FUNCTION
-void
-AMQP_CALL amqp_set_heartbeat_ex(amqp_connection_state_t state, amqp_send_heartbeat_ex_t send_func, amqp_on_receive_heartbeat_t recv_func, void *context);
+void AMQP_CALL amqp_set_heartbeat_ex(amqp_connection_state_t state, 
+                                     amqp_send_heartbeat_ex_t send_func, 
+                                     amqp_on_receive_heartbeat_t recv_func, 
+                                     void *context);
 
 /**
  * Get the underlying socket descriptor for the connection
@@ -1695,8 +1699,7 @@ int AMQP_CALL amqp_send_method(amqp_connection_state_t state,
  * \since v0.8.1
  */
 AMQP_PUBLIC_FUNCTION
-int
-AMQP_CALL amqp_send_heartbeat(amqp_connection_state_t state, void *ctx);
+int AMQP_CALL amqp_send_heartbeat(amqp_connection_state_t state, void *ctx);
 
 /**
  * Sends a method to the broker and waits for a method response

--- a/librabbitmq/amqp_connection.c
+++ b/librabbitmq/amqp_connection.c
@@ -121,9 +121,9 @@ out_nomem:
   return NULL;
 }
 
-void amqp_set_heartbeat_ex(amqp_connection_state_t state, 
+void amqp_set_heartbeat_ex(amqp_connection_state_t state,
                            amqp_send_heartbeat_ex_t send_func,
-                           amqp_on_receive_heartbeat_t recv_func, 
+                           amqp_on_receive_heartbeat_t recv_func,
                            void *context) {
   state->send_heartbeat_func = send_func;
   state->on_receive_heartbeat_func = recv_func;

--- a/librabbitmq/amqp_connection.c
+++ b/librabbitmq/amqp_connection.c
@@ -121,9 +121,10 @@ out_nomem:
   return NULL;
 }
 
-void amqp_set_heartbeat_ex(amqp_connection_state_t state, amqp_send_heartbeat_ex_t send_func,
-                           amqp_on_receive_heartbeat_t recv_func, void *context)
-{
+void amqp_set_heartbeat_ex(amqp_connection_state_t state, 
+                           amqp_send_heartbeat_ex_t send_func,
+                           amqp_on_receive_heartbeat_t recv_func, 
+                           void *context) {
   state->send_heartbeat_func = send_func;
   state->on_receive_heartbeat_func = recv_func;
   state->appli_heartbeat_ctx = context;
@@ -398,7 +399,7 @@ int amqp_handle_input(amqp_connection_state_t state, amqp_bytes_t received_data,
 
         case AMQP_FRAME_HEARTBEAT:
           if (state->on_receive_heartbeat_func)
-              state->on_receive_heartbeat_func(state->appli_heartbeat_ctx);
+            state->on_receive_heartbeat_func(state->appli_heartbeat_ctx);
           break;
 
         default:

--- a/librabbitmq/amqp_private.h
+++ b/librabbitmq/amqp_private.h
@@ -189,6 +189,10 @@ struct amqp_connection_state_t_ {
   amqp_table_t client_properties;
   amqp_pool_t properties_pool;
 
+  amqp_send_heartbeat_ex_t send_heartbeat_func;
+  amqp_on_receive_heartbeat_t on_receive_heartbeat_func;
+  void *appli_heartbeat_ctx;
+
   struct timeval *handshake_timeout;
   struct timeval internal_handshake_timeout;
   struct timeval *rpc_timeout;

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -795,11 +795,7 @@ static int wait_frame_inner(amqp_connection_state_t state,
     if (AMQP_STATUS_TIMER_FAILURE == res) {
       return res;
     } else if (AMQP_STATUS_TIMEOUT == res) {
-      amqp_frame_t heartbeat;
-      heartbeat.channel = 0;
-      heartbeat.frame_type = AMQP_FRAME_HEARTBEAT;
-
-      res = amqp_send_frame(state, &heartbeat);
+      res = state->send_heartbeat_func(state, state->appli_heartbeat_ctx);
       if (AMQP_STATUS_OK != res) {
         return res;
       }
@@ -1009,6 +1005,14 @@ int amqp_send_method(amqp_connection_state_t state, amqp_channel_t channel,
                      amqp_method_number_t id, void *decoded) {
   return amqp_send_method_inner(state, channel, id, decoded, AMQP_SF_NONE,
                                 amqp_time_infinite());
+}
+
+int amqp_send_heartbeat(amqp_connection_state_t state, void *ctx) {
+  amqp_frame_t heartbeat;
+  heartbeat.channel = 0;
+  heartbeat.frame_type = AMQP_FRAME_HEARTBEAT;
+
+  return amqp_send_frame(state, &heartbeat);
 }
 
 int amqp_send_method_inner(amqp_connection_state_t state,

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -1007,7 +1007,7 @@ int amqp_send_method(amqp_connection_state_t state, amqp_channel_t channel,
                                 amqp_time_infinite());
 }
 
-int amqp_send_heartbeat(amqp_connection_state_t state, void *ctx) {
+int amqp_send_heartbeat(amqp_connection_state_t state, void AMQP_UNUSED *ctx) {
   amqp_frame_t heartbeat;
   heartbeat.channel = 0;
   heartbeat.frame_type = AMQP_FRAME_HEARTBEAT;


### PR DESCRIPTION
Hi,
I am using this library in multi-threaded context for years (starting with version 0.2) but since few releases this was not possible anymore because heartbeats were handle inside the library.
In this fork, an extension is proposed to allow multi-threaded application to handle locks over the heartbeats managed by the library.
Doing so, the access to connection_state and the socket can be fully managed for exclusivity by the application level.
Best regards.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/466)
<!-- Reviewable:end -->
