### PR TITLE
Examples: Update amqp_ssl_connect.c to show how to un-initialize SSL library.

### DIFF
--- a/examples/amqp_ssl_connect.c
+++ b/examples/amqp_ssl_connect.c
@@ -128,6 +128,7 @@ int main(int argc, char const *const *argv) {
   die_on_amqp_error(amqp_connection_close(conn, AMQP_REPLY_SUCCESS),
                     "Closing connection");
   die_on_error(amqp_destroy_connection(conn), "Ending connection");
+  die_on_error(amqp_uninitialize_ssl_library(), "Uninitializing SSL library");
 
   printf("Done\n");
   return 0;


### PR DESCRIPTION
Hi @alanxz ,

I pulled your latest changes and saw that now it is necessary to explicitly un-initialize OpenSSL after commit b80de27b, otherwise my valgrind detects a memory leak. 

I added a call to function `amqp_uninitialize_ssl_library()` to my code and worked perfectly, so I thought to submit this change to the amqp_ssl_connect example, so other people are aware of it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/476)
<!-- Reviewable:end -->
