### PR TITLE
Lib: Fixed an invalid CHECK_SUCCESS in amqp_set_initialize_ssl_library

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -544,7 +544,7 @@ void amqp_set_initialize_ssl_library(amqp_boolean_t do_initialize) {
   if (openssl_connections == 0 && !openssl_initialized) {
     do_initialize_openssl = do_initialize;
   }
-  CHECK_SUCCESS(!pthread_mutex_unlock(&openssl_init_mutex));
+  CHECK_SUCCESS(pthread_mutex_unlock(&openssl_init_mutex));
 }
 
 static unsigned long ssl_threadid_callback(void) {


### PR DESCRIPTION
There's an ! that shouldn't be there in amqp_set_initialize_ssl_library().
This patch removes it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/491)
<!-- Reviewable:end -->
