### PR TITLE
OpenSSL should ignore missing config file

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -584,8 +584,9 @@ static int setup_openssl(void) {
   CRYPTO_set_locking_callback(ssl_locking_callback);
 
 #ifdef AMQP_OPENSSL_V110
-  if (CONF_modules_load_file(NULL, "rabbitmq-c", CONF_MFLAGS_DEFAULT_SECTION) <=
-      0) {
+  if (CONF_modules_load_file(
+          NULL, "rabbitmq-c",
+          CONF_MFLAGS_DEFAULT_SECTION | CONF_MFLAGS_IGNORE_MISSING_FILE) <= 0) {
     status = AMQP_STATUS_SSL_ERROR;
     goto out;
   }


### PR DESCRIPTION
When initializing OpenSSL in v1.1.0 or later, tell OpenSSL to ignore
missing openssl.cnf.

Fixes #523

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/526)
<!-- Reviewable:end -->
