### PR TITLE
Make cmake build reproducibly

### DIFF
--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -9,6 +9,6 @@
 
 #cmakedefine HAVE_POLL
 
-#define AMQ_PLATFORM "@CMAKE_SYSTEM@"
+#define AMQ_PLATFORM "@CMAKE_SYSTEM_NAME@"
 
 #endif /* CONFIG_H */


### PR DESCRIPTION
While working on the [reproducible build](https://reproducible-builds.org/) project, I noticed that rabbitmq-c could not be build reproducibly because it embeds the kernel version. 

This patch makes the output consistent across kernel versions by using the `CMAKE_SYSTEM_NAME` instead of `CMAKE_SYSTEM`.