### PR TITLE
ssl: Add amqp_ssl_socket_get_context()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,31 @@
 
 language: c
 
-dist: trusty
+dist: xenial
 # Currently libpopt-dev is not on the list of whitelisted apt-packages.
 sudo: true
+
+addons:
+  apt:
+    packages: &default_packages
+      - rabbitmq-server
+      - clang-3.9
+      - clang-format-3.9
+      - libpopt-dev
+  coverity_scan:
+    project:
+      name: "alanxz/rabbitmq-c"
+      description: "C AMQP client for RabbitMQ"
+    notification_email: alan.antonuk@gmail.com
+    build_command_prepend: mkdir build && pushd build && cmake .. && popd
+    build_command: cmake --build ./build
+    branch_pattern: coverity_scan
 
 env:
   global:
    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
    #   via the "travis encrypt" command using the project repo's public key
    - secure: "gDwqo3jHj+HHGzFKnxL/nwZhbVeh2pItw0TbeaHcLtWubUZaf85ViEQRaXPyfnbG7l0OEQq+PjyhKAfvViVq2NP0lGeeu4VM5uMZJhsCLN594BJr39Y4XzOapg0O8mEMhQ0DU2u1Zo4LMgEcRz67aosVQOj6QV30tOzp9fnxn9U="
-
-services:
-  - rabbitmq
 
 matrix:
   include:
@@ -52,6 +65,7 @@ matrix:
           sources:
           - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
+          - *default_packages
           - libssl1.1
           - openssl
           - libssl-dev
@@ -62,13 +76,6 @@ matrix:
       env: CONFIG=tsan
 
 before_install:
-  - |
-    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-      sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main"
-      sudo apt-get -q update;
-      sudo apt-get install -y clang-3.9 clang-format-3.9 libpopt-dev;
-    fi
   # ugly hack; if running a coverity scan abort all except the 1st build
   # see note re gcc compiler above needing to be 1st
   # also note that branch_pattern & the TRAVIS_BRANCH check must match
@@ -80,13 +87,3 @@ before_install:
 script:
   # Don't bother building if this is being done in the coverity_scan branch.
   - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then ./travis.sh $CONFIG ; fi
-
-addons:
-  coverity_scan:
-    project:
-      name: "alanxz/rabbitmq-c"
-      description: "C AMQP client for RabbitMQ"
-    notification_email: alan.antonuk@gmail.com
-    build_command_prepend: mkdir build && pushd build && cmake .. && popd
-    build_command: cmake --build ./build
-    branch_pattern: coverity_scan

--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -363,6 +363,13 @@ error:
   return NULL;
 }
 
+void *amqp_ssl_socket_get_context(amqp_socket_t *base) {
+  if (base->klass != &amqp_ssl_socket_class) {
+    amqp_abort("<%p> is not of type amqp_ssl_socket_t", base);
+  }
+  return ((struct amqp_ssl_socket_t *)base)->ctx;
+}
+
 int amqp_ssl_socket_set_cacert(amqp_socket_t *base, const char *cacert) {
   int status;
   struct amqp_ssl_socket_t *self;

--- a/librabbitmq/amqp_ssl_socket.h
+++ b/librabbitmq/amqp_ssl_socket.h
@@ -58,6 +58,19 @@ AMQP_PUBLIC_FUNCTION
 amqp_socket_t *AMQP_CALL amqp_ssl_socket_new(amqp_connection_state_t state);
 
 /**
+ * Get the internal OpenSSL context. Caveat emptor.
+ *
+ * \param [in,out] self An SSL/TLS socket object.
+ *
+ * \return A pointer to the internal OpenSSL context. This should be cast to
+ * <tt>SSL_CTX*</tt>.
+ *
+ * \since v0.9.0
+ */
+AMQP_PUBLIC_FUNCTION
+void *AMQP_CALL amqp_ssl_socket_get_context(amqp_socket_t *self);
+
+/**
  * Set the CA certificate.
  *
  * \param [in,out] self An SSL/TLS socket object.


### PR DESCRIPTION
Useful if the user needs to do custom OpenSSLy things such as injecting in-memory certificates. Am currently using the ugly hack below.
```c++
void nimrod::set_ssl_store(SSL_CTX *ctx, X509_STORE *st)
{
	SSL_CTX_set_cert_store(ctx, st);

	/* SSL_CTX_set_cert_store() doesn't add a reference, so do it here. */
	CRYPTO_add(&ctx->references, 1, CRYPTO_LOCK_X509_STORE);
}

void nimrod::amqp_inject_x509_store(amqp_socket_t *socket, X509_STORE *ctx)
{
	if(ctx == nullptr)
		return;

	struct hack
	{
		const struct amqp_socket_class_t *klass;
		SSL_CTX *ctx;
	};


	struct hack *h = reinterpret_cast<struct hack*>(socket);

	set_ssl_store(h->ctx, ctx);
}
```

The patch would change it to:
```c++
SSL_CTX *ctx = reinterpret_cast<SSL_CTX*>(amqp_ssl_socket_get_context(socket));
set_ssl_store(ctx, castore);
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/560)
<!-- Reviewable:end -->
