### PR TITLE
ci: Bump Travis dist to Xenial as Trusty is now EOL

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,18 +3,31 @@
 
 language: c
 
-dist: trusty
+dist: xenial
 # Currently libpopt-dev is not on the list of whitelisted apt-packages.
 sudo: true
+
+addons:
+  apt:
+    packages: &default_packages
+      - rabbitmq-server
+      - clang-3.9
+      - clang-format-3.9
+      - libpopt-dev
+  coverity_scan:
+    project:
+      name: "alanxz/rabbitmq-c"
+      description: "C AMQP client for RabbitMQ"
+    notification_email: alan.antonuk@gmail.com
+    build_command_prepend: mkdir build && pushd build && cmake .. && popd
+    build_command: cmake --build ./build
+    branch_pattern: coverity_scan
 
 env:
   global:
    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
    #   via the "travis encrypt" command using the project repo's public key
    - secure: "gDwqo3jHj+HHGzFKnxL/nwZhbVeh2pItw0TbeaHcLtWubUZaf85ViEQRaXPyfnbG7l0OEQq+PjyhKAfvViVq2NP0lGeeu4VM5uMZJhsCLN594BJr39Y4XzOapg0O8mEMhQ0DU2u1Zo4LMgEcRz67aosVQOj6QV30tOzp9fnxn9U="
-
-services:
-  - rabbitmq
 
 matrix:
   include:
@@ -52,6 +65,7 @@ matrix:
           sources:
           - sourceline: 'ppa:ondrej/nginx-mainline'
           packages:
+          - *default_packages
           - libssl1.1
           - openssl
           - libssl-dev
@@ -62,13 +76,6 @@ matrix:
       env: CONFIG=tsan
 
 before_install:
-  - |
-    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      wget -O - http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-      sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-3.9 main"
-      sudo apt-get -q update;
-      sudo apt-get install -y clang-3.9 clang-format-3.9 libpopt-dev;
-    fi
   # ugly hack; if running a coverity scan abort all except the 1st build
   # see note re gcc compiler above needing to be 1st
   # also note that branch_pattern & the TRAVIS_BRANCH check must match
@@ -80,13 +87,3 @@ before_install:
 script:
   # Don't bother building if this is being done in the coverity_scan branch.
   - if [ "${COVERITY_SCAN_BRANCH}" != 1 ]; then ./travis.sh $CONFIG ; fi
-
-addons:
-  coverity_scan:
-    project:
-      name: "alanxz/rabbitmq-c"
-      description: "C AMQP client for RabbitMQ"
-    notification_email: alan.antonuk@gmail.com
-    build_command_prepend: mkdir build && pushd build && cmake .. && popd
-    build_command: cmake --build ./build
-    branch_pattern: coverity_scan


### PR DESCRIPTION
Ubuntu Trusty is EOL as of April, so bump the distro to Xenial. This also fixes the OpenSSL download error that's causing build failures.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/561)
<!-- Reviewable:end -->
