### PR TITLE
ssl: fix OpenSSL modes to correct non-blocking behavior

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -355,6 +355,11 @@ amqp_socket_t *amqp_ssl_socket_new(amqp_connection_state_t state) {
   /* Disable SSLv2 and SSLv3 */
   SSL_CTX_set_options(self->ctx, SSL_OP_NO_SSLv2 | SSL_OP_NO_SSLv3);
 
+  SSL_CTX_set_mode(self->ctx, SSL_MODE_ENABLE_PARTIAL_WRITE);
+  /* OpenSSL v1.1.1 turns this on by default, which makes the non-blocking
+   * logic not behave as expected, so turn this back off */
+  SSL_CTX_clear_mode(self->ctx, SSL_MODE_AUTO_RETRY);
+
   amqp_set_socket(state, (amqp_socket_t *)self);
 
   return (amqp_socket_t *)self;


### PR DESCRIPTION
OpenSSL changed the default in v1.1.1 of SSL_MODE_AUTO_RETRY from off to
on. Because rabbitmq-c uses non-blocking calls internally, this must be
disabled.

Additionally turn on SSL_MODE_ENABLE_PARTIAL_WRITE to allow SSL_write to
return before a full frame is written. This is likely a latent bug that
hasn't been found until recently.

Fixes #586

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/587)
<!-- Reviewable:end -->
