### PR TITLE
win32: disable secure CRT warnings in OpenSSL code

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -28,6 +28,10 @@
 #include "config.h"
 #endif
 
+#ifdef _MSC_VER
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
 #include "amqp_openssl_bio.h"
 #include "amqp_openssl_hostname_validation.h"
 #include "amqp_private.h"


### PR DESCRIPTION
These warnings have been disabled in other parts of the code and are
generally harmless. Recent refactoring in the amqp_openssl.c file have
caused these warnings to appear.

Fixes: #588

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/alanxz/rabbitmq-c/589)
<!-- Reviewable:end -->
