### PR TITLE
Make all timeval's constant

### DIFF
--- a/librabbitmq/amqp.h
+++ b/librabbitmq/amqp.h
@@ -1548,7 +1548,7 @@ int AMQP_CALL amqp_simple_wait_frame(amqp_connection_state_t state,
 AMQP_PUBLIC_FUNCTION
 int AMQP_CALL amqp_simple_wait_frame_noblock(amqp_connection_state_t state,
                                              amqp_frame_t *decoded_frame,
-                                             struct timeval *tv);
+                                             const struct timeval *tv);
 
 /**
  * Waits for a specific method from the broker
@@ -2245,7 +2245,7 @@ typedef struct amqp_envelope_t_ {
 AMQP_PUBLIC_FUNCTION
 amqp_rpc_reply_t AMQP_CALL amqp_consume_message(amqp_connection_state_t state,
                                                 amqp_envelope_t *envelope,
-                                                struct timeval *timeout,
+                                                const struct timeval *timeout,
                                                 int flags);
 
 /**
@@ -2365,7 +2365,7 @@ int AMQP_CALL amqp_socket_open(amqp_socket_t *self, const char *host, int port);
  */
 AMQP_PUBLIC_FUNCTION
 int AMQP_CALL amqp_socket_open_noblock(amqp_socket_t *self, const char *host,
-                                       int port, struct timeval *timeout);
+                                       int port, const struct timeval *timeout);
 
 /**
  * Get the socket descriptor in use by a socket object.
@@ -2473,7 +2473,7 @@ struct timeval *AMQP_CALL
  */
 AMQP_PUBLIC_FUNCTION
 int AMQP_CALL amqp_set_handshake_timeout(amqp_connection_state_t state,
-                                         struct timeval *timeout);
+                                         const struct timeval *timeout);
 
 /**
  * Get the RPC timeout
@@ -2531,7 +2531,7 @@ struct timeval *AMQP_CALL amqp_get_rpc_timeout(amqp_connection_state_t state);
  */
 AMQP_PUBLIC_FUNCTION
 int AMQP_CALL amqp_set_rpc_timeout(amqp_connection_state_t state,
-                                   struct timeval *timeout);
+                                   const struct timeval *timeout);
 
 AMQP_END_DECLS
 

--- a/librabbitmq/amqp_api.c
+++ b/librabbitmq/amqp_api.c
@@ -361,7 +361,7 @@ struct timeval *amqp_get_handshake_timeout(amqp_connection_state_t state) {
 }
 
 int amqp_set_handshake_timeout(amqp_connection_state_t state,
-                               struct timeval *timeout) {
+                               const struct timeval *timeout) {
   if (timeout) {
     if (timeout->tv_sec < 0 || timeout->tv_usec < 0) {
       return AMQP_STATUS_INVALID_PARAMETER;
@@ -380,7 +380,7 @@ struct timeval *amqp_get_rpc_timeout(amqp_connection_state_t state) {
 }
 
 int amqp_set_rpc_timeout(amqp_connection_state_t state,
-                         struct timeval *timeout) {
+                         const struct timeval *timeout) {
   if (timeout) {
     if (timeout->tv_sec < 0 || timeout->tv_usec < 0) {
       return AMQP_STATUS_INVALID_PARAMETER;

--- a/librabbitmq/amqp_consumer.c
+++ b/librabbitmq/amqp_consumer.c
@@ -134,7 +134,7 @@ static int amqp_bytes_malloc_dup_failed(amqp_bytes_t bytes) {
 
 amqp_rpc_reply_t amqp_consume_message(amqp_connection_state_t state,
                                       amqp_envelope_t *envelope,
-                                      struct timeval *timeout,
+                                      const struct timeval *timeout,
                                       AMQP_UNUSED int flags) {
   int res;
   amqp_frame_t frame;

--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -168,7 +168,7 @@ static ssize_t amqp_ssl_socket_recv(void *base, void *buf, size_t len,
 }
 
 static int amqp_ssl_socket_open(void *base, const char *host, int port,
-                                struct timeval *timeout) {
+                                const struct timeval *timeout) {
   struct amqp_ssl_socket_t *self = (struct amqp_ssl_socket_t *)base;
   long result;
   int status;

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -1226,10 +1226,13 @@ error_out:
   return res;
 }
 
-static amqp_rpc_reply_t amqp_login_inner(
-    amqp_connection_state_t state, char const *vhost, int channel_max,
-    int frame_max, int heartbeat, const amqp_table_t *client_properties,
-    const struct timeval *timeout, amqp_sasl_method_enum sasl_method, va_list vl) {
+static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
+                                         char const *vhost, int channel_max,
+                                         int frame_max, int heartbeat,
+                                         const amqp_table_t *client_properties,
+                                         const struct timeval *timeout,
+                                         amqp_sasl_method_enum sasl_method,
+                                         va_list vl) {
   int res;
   amqp_method_t method;
 

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -139,7 +139,7 @@ int amqp_socket_open(amqp_socket_t *self, const char *host, int port) {
 }
 
 int amqp_socket_open_noblock(amqp_socket_t *self, const char *host, int port,
-                             struct timeval *timeout) {
+                             const struct timeval *timeout) {
   assert(self);
   assert(self->klass->open);
   return self->klass->open(self, host, port, timeout);
@@ -312,7 +312,7 @@ int amqp_open_socket(char const *hostname, int portnumber) {
 }
 
 int amqp_open_socket_noblock(char const *hostname, int portnumber,
-                             struct timeval *timeout) {
+                             const struct timeval *timeout) {
   amqp_time_t deadline;
   int res = amqp_time_from_now(&deadline, timeout);
   if (AMQP_STATUS_OK != res) {
@@ -938,7 +938,7 @@ int amqp_simple_wait_frame(amqp_connection_state_t state,
 
 int amqp_simple_wait_frame_noblock(amqp_connection_state_t state,
                                    amqp_frame_t *decoded_frame,
-                                   struct timeval *timeout) {
+                                   const struct timeval *timeout) {
   amqp_time_t deadline;
 
   int res = amqp_time_from_now(&deadline, timeout);
@@ -1229,7 +1229,7 @@ error_out:
 static amqp_rpc_reply_t amqp_login_inner(
     amqp_connection_state_t state, char const *vhost, int channel_max,
     int frame_max, int heartbeat, const amqp_table_t *client_properties,
-    struct timeval *timeout, amqp_sasl_method_enum sasl_method, va_list vl) {
+    const struct timeval *timeout, amqp_sasl_method_enum sasl_method, va_list vl) {
   int res;
   amqp_method_t method;
 

--- a/librabbitmq/amqp_socket.h
+++ b/librabbitmq/amqp_socket.h
@@ -53,7 +53,7 @@ int amqp_os_socket_close(int sockfd);
 /* Socket callbacks. */
 typedef ssize_t (*amqp_socket_send_fn)(void *, const void *, size_t, int);
 typedef ssize_t (*amqp_socket_recv_fn)(void *, void *, size_t, int);
-typedef int (*amqp_socket_open_fn)(void *, const char *, int, struct timeval *);
+typedef int (*amqp_socket_open_fn)(void *, const char *, int, const struct timeval *);
 typedef int (*amqp_socket_close_fn)(void *, amqp_socket_close_enum);
 typedef int (*amqp_socket_get_sockfd_fn)(void *);
 typedef void (*amqp_socket_delete_fn)(void *);
@@ -157,7 +157,7 @@ void amqp_socket_delete(amqp_socket_t *self);
  * \return File descriptor upon success, non-zero negative error code otherwise.
  */
 int amqp_open_socket_noblock(char const *hostname, int portnumber,
-                             struct timeval *timeout);
+                             const struct timeval *timeout);
 
 int amqp_open_socket_inner(char const *hostname, int portnumber,
                            amqp_time_t deadline);

--- a/librabbitmq/amqp_socket.h
+++ b/librabbitmq/amqp_socket.h
@@ -53,7 +53,8 @@ int amqp_os_socket_close(int sockfd);
 /* Socket callbacks. */
 typedef ssize_t (*amqp_socket_send_fn)(void *, const void *, size_t, int);
 typedef ssize_t (*amqp_socket_recv_fn)(void *, void *, size_t, int);
-typedef int (*amqp_socket_open_fn)(void *, const char *, int, const struct timeval *);
+typedef int (*amqp_socket_open_fn)(void *, const char *, int,
+                                   const struct timeval *);
 typedef int (*amqp_socket_close_fn)(void *, amqp_socket_close_enum);
 typedef int (*amqp_socket_get_sockfd_fn)(void *);
 typedef void (*amqp_socket_delete_fn)(void *);

--- a/librabbitmq/amqp_tcp_socket.c
+++ b/librabbitmq/amqp_tcp_socket.c
@@ -163,7 +163,7 @@ start:
 }
 
 static int amqp_tcp_socket_open(void *base, const char *host, int port,
-                                struct timeval *timeout) {
+                                const struct timeval *timeout) {
   struct amqp_tcp_socket_t *self = (struct amqp_tcp_socket_t *)base;
   if (-1 != self->sockfd) {
     return AMQP_STATUS_SOCKET_INUSE;

--- a/librabbitmq/amqp_time.c
+++ b/librabbitmq/amqp_time.c
@@ -101,7 +101,7 @@ uint64_t amqp_get_monotonic_timestamp(void) {
 }
 #endif /* AMQP_POSIX_TIMER_API */
 
-int amqp_time_from_now(amqp_time_t *time, struct timeval *timeout) {
+int amqp_time_from_now(amqp_time_t *time, const struct timeval *timeout) {
   uint64_t now_ns;
   uint64_t delta_ns;
 
@@ -199,7 +199,7 @@ int amqp_time_ms_until(amqp_time_t time) {
   return left_ms;
 }
 
-int amqp_time_tv_until(amqp_time_t time, struct timeval *in,
+int amqp_time_tv_until(amqp_time_t time, const struct timeval *in,
                        struct timeval **out) {
   uint64_t now_ns;
   uint64_t delta_ns;
@@ -210,9 +210,8 @@ int amqp_time_tv_until(amqp_time_t time, struct timeval *in,
     return AMQP_STATUS_OK;
   }
   if (0 == time.time_point_ns) {
-    in->tv_sec = 0;
-    in->tv_usec = 0;
-    *out = in;
+    (*out)->tv_sec = 0;
+    (*out)->tv_usec = 0;
     return AMQP_STATUS_OK;
   }
 
@@ -222,16 +221,14 @@ int amqp_time_tv_until(amqp_time_t time, struct timeval *in,
   }
 
   if (now_ns >= time.time_point_ns) {
-    in->tv_sec = 0;
-    in->tv_usec = 0;
-    *out = in;
+    (*out)->tv_sec = 0;
+    (*out)->tv_usec = 0;
     return AMQP_STATUS_OK;
   }
 
   delta_ns = time.time_point_ns - now_ns;
-  in->tv_sec = (int)(delta_ns / AMQP_NS_PER_S);
-  in->tv_usec = (int)((delta_ns % AMQP_NS_PER_S) / AMQP_NS_PER_US);
-  *out = in;
+  (*out)->tv_sec = (int)(delta_ns / AMQP_NS_PER_S);
+  (*out)->tv_usec = (int)((delta_ns % AMQP_NS_PER_S) / AMQP_NS_PER_US);
 
   return AMQP_STATUS_OK;
 }

--- a/librabbitmq/amqp_time.c
+++ b/librabbitmq/amqp_time.c
@@ -199,7 +199,7 @@ int amqp_time_ms_until(amqp_time_t time) {
   return left_ms;
 }
 
-int amqp_time_tv_until(amqp_time_t time, const struct timeval *in,
+int amqp_time_tv_until(amqp_time_t time, struct timeval *in,
                        struct timeval **out) {
   uint64_t now_ns;
   uint64_t delta_ns;
@@ -210,8 +210,9 @@ int amqp_time_tv_until(amqp_time_t time, const struct timeval *in,
     return AMQP_STATUS_OK;
   }
   if (0 == time.time_point_ns) {
-    (*out)->tv_sec = 0;
-    (*out)->tv_usec = 0;
+    in->tv_sec = 0;
+    in->tv_usec = 0;
+    *out = in;
     return AMQP_STATUS_OK;
   }
 
@@ -221,14 +222,16 @@ int amqp_time_tv_until(amqp_time_t time, const struct timeval *in,
   }
 
   if (now_ns >= time.time_point_ns) {
-    (*out)->tv_sec = 0;
-    (*out)->tv_usec = 0;
+    in->tv_sec = 0;
+    in->tv_usec = 0;
+    *out = in;
     return AMQP_STATUS_OK;
   }
 
   delta_ns = time.time_point_ns - now_ns;
-  (*out)->tv_sec = (int)(delta_ns / AMQP_NS_PER_S);
-  (*out)->tv_usec = (int)((delta_ns % AMQP_NS_PER_S) / AMQP_NS_PER_US);
+  in->tv_sec = (int)(delta_ns / AMQP_NS_PER_S);
+  in->tv_usec = (int)((delta_ns % AMQP_NS_PER_S) / AMQP_NS_PER_US);
+  *out = in;
 
   return AMQP_STATUS_OK;
 }

--- a/librabbitmq/amqp_time.h
+++ b/librabbitmq/amqp_time.h
@@ -109,7 +109,7 @@ int amqp_time_ms_until(amqp_time_t time);
  * AMQP_STATUS_TIMER_FAILURE is returned when the underlying call to get the
  * current timestamp fails.
  */
-int amqp_time_tv_until(amqp_time_t time, const struct timeval *in,
+int amqp_time_tv_until(amqp_time_t time, struct timeval *in,
                        struct timeval **out);
 
 /* Test whether current time is past the provided time.

--- a/librabbitmq/amqp_time.h
+++ b/librabbitmq/amqp_time.h
@@ -69,7 +69,7 @@ uint64_t amqp_get_monotonic_timestamp(void);
  * AMQP_STATUS_TIMER_FAILURE if the underlying call to get the current timestamp
  * fails.
  */
-int amqp_time_from_now(amqp_time_t *time, struct timeval *timeout);
+int amqp_time_from_now(amqp_time_t *time, const struct timeval *timeout);
 
 /* Get a amqp_time_t that is seconds from now.
  * If seconds <= 0, then amqp_time_infinite() is created.
@@ -109,7 +109,7 @@ int amqp_time_ms_until(amqp_time_t time);
  * AMQP_STATUS_TIMER_FAILURE is returned when the underlying call to get the
  * current timestamp fails.
  */
-int amqp_time_tv_until(amqp_time_t time, struct timeval *in,
+int amqp_time_tv_until(amqp_time_t time, const struct timeval *in,
                        struct timeval **out);
 
 /* Test whether current time is past the provided time.


### PR DESCRIPTION
These changes make it possible to sent constant timevals through the functions.
It wasn't necessary to have them non-const anyhow (and I like to define those never-changing entries as a constant in my code).

The only thing that was a bit "tricky" logical wise was "amqp_time_tv_until". But even there the "in" parameter wasn't used afterwards, so I changed it.