### PR TITLE
win32: define AMQP_UNUSED for win32

### DIFF
--- a/librabbitmq/amqp_private.h
+++ b/librabbitmq/amqp_private.h
@@ -71,7 +71,7 @@
 #define AMQP_UNUSED __attribute__((__unused__))
 #elif defined(_MSC_VER)
 #define AMQP_NORETURN __declspec(noreturn)
-#define AMQP_UNUSED
+#define AMQP_UNUSED __pragma(warning(suppress : 4100))
 #else
 #define AMQP_NORETURN
 #define AMQP_UNUSED


### PR DESCRIPTION
Does not provide any sort of optimization help for win32.

Fixes #591