### PR TITLE
Fix mem leak in amqp_listen example

### DIFF
--- a/examples/amqp_consumer.c
+++ b/examples/amqp_consumer.c
@@ -205,6 +205,8 @@ int main(int argc, char const *const *argv) {
 
   run(conn);
 
+  amqp_bytes_free(queuename);
+
   die_on_amqp_error(amqp_channel_close(conn, 1, AMQP_REPLY_SUCCESS),
                     "Closing channel");
   die_on_amqp_error(amqp_connection_close(conn, AMQP_REPLY_SUCCESS),

--- a/examples/amqp_listen.c
+++ b/examples/amqp_listen.c
@@ -133,6 +133,8 @@ int main(int argc, char const *const *argv) {
     }
   }
 
+  amqp_bytes_free(queuename);
+
   die_on_amqp_error(amqp_channel_close(conn, 1, AMQP_REPLY_SUCCESS),
                     "Closing channel");
   die_on_amqp_error(amqp_connection_close(conn, AMQP_REPLY_SUCCESS),


### PR DESCRIPTION
Frees heap allocated memory in queuename.bytes on exit.