### PR TITLE
Add vcpkg installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,18 @@ Other interesting flags that can be passed to CMake:
 * `RUN_SYSTEM_TESTS=ON/OFF` toggles building the system tests (i.e. tests requiring 
    an accessible RabbitMQ server instance on localhost), by default this is OFF
 
+## Building RabbitMQ - Using vcpkg
+
+You can download and install RabbitMQ using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+
+    git clone https://github.com/Microsoft/vcpkg.git
+    cd vcpkg
+    ./bootstrap-vcpkg.sh
+    ./vcpkg integrate install
+    ./vcpkg install librabbitmq
+
+The RabbitMQ port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+
 ## Running the examples
 
 Arrange for a RabbitMQ or other AMQP server to be running on

--- a/README.md
+++ b/README.md
@@ -89,7 +89,8 @@ Other interesting flags that can be passed to CMake:
 
 ## Building RabbitMQ - Using vcpkg
 
-You can download and install RabbitMQ using the [vcpkg](https://github.com/Microsoft/vcpkg) dependency manager:
+You can download and install RabbitMQ using the [vcpkg](https://github.com/Microsoft/vcpkg) 
+dependency manager:
 
     git clone https://github.com/Microsoft/vcpkg.git
     cd vcpkg
@@ -97,7 +98,9 @@ You can download and install RabbitMQ using the [vcpkg](https://github.com/Micro
     ./vcpkg integrate install
     ./vcpkg install librabbitmq
 
-The RabbitMQ port in vcpkg is kept up to date by Microsoft team members and community contributors. If the version is out of date, please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
+The RabbitMQ port in vcpkg is kept up to date by Microsoft team members and 
+community contributors. If the version is out of date, 
+please [create an issue or pull request](https://github.com/Microsoft/vcpkg) on the vcpkg repository.
 
 ## Running the examples
 


### PR DESCRIPTION
RabbitMQ is available as a port in vcpkg, a C++ library manager that simplifies installation for RabbitMQ and other project dependencies. Documenting the install process here will help users get started by providing a single set of commands to build RabbitMQ, ready to be included in their projects.

We also test whether our library ports build in various configurations (dynamic, static) on various platforms (OSX, Linux, Windows: x86, x64, UWP, ARM) to keep a wide coverage for users.

I'm a maintainer for vcpkg, and here is what the port script looks like. We try to keep the library maintained as close as possible to the original library.