### PR TITLE
Add rabbitmq-c-config.cmake generation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -272,6 +272,8 @@ if (NOT BUILD_SHARED_LIBS AND NOT BUILD_STATIC_LIBS)
     message(FATAL_ERROR "One or both of BUILD_SHARED_LIBS or BUILD_STATIC_LIBS must be set to ON to build")
 endif()
 
+set(targets_export_name rabbitmq-targets)
+
 add_subdirectory(librabbitmq)
 
 if (BUILD_EXAMPLES)
@@ -328,6 +330,43 @@ set(includedir "\${prefix}/${CMAKE_INSTALL_INCLUDEDIR}")
 
 configure_file(cmake/config.h.in ${CMAKE_CURRENT_BINARY_DIR}/librabbitmq/config.h)
 configure_file(librabbitmq.pc.in ${CMAKE_CURRENT_BINARY_DIR}/librabbitmq.pc @ONLY)
+
+
+include(CMakePackageConfigHelpers)
+set(RMQ_CMAKE_DIR ${CMAKE_INSTALL_LIBDIR}/cmake/rabbitmq-c)
+set(project_config "${CMAKE_CURRENT_BINARY_DIR}/rabbitmq-c-config.cmake")
+set(version_config "${CMAKE_CURRENT_BINARY_DIR}/rabbitmq-c-config-version.cmake")
+
+write_basic_package_version_file(
+    "${version_config}"
+    VERSION ${RMQ_VERSION}
+    COMPATIBILITY AnyNewerVersion)
+
+configure_package_config_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/rabbitmq-c-config.cmake.in"
+    "${project_config}"
+    INSTALL_DESTINATION "${RMQ_CMAKE_DIR}")
+
+
+if(BUILD_SHARED_LIBS)
+    list(APPEND INSTALL_TARGETS rabbitmq)
+endif()
+if(BUILD_STATIC_LIBS)
+    list(APPEND INSTALL_TARGETS rabbitmq-static)
+endif()
+
+export(TARGETS ${INSTALL_TARGETS} 
+    NAMESPACE rabbitmq:: 
+    FILE ${PROJECT_BINARY_DIR}/${targets_export_name}.cmake)
+
+install(FILES ${project_config} ${version_config}
+    DESTINATION ${RMQ_CMAKE_DIR}
+    )
+
+install(EXPORT ${targets_export_name} 
+    DESTINATION ${RMQ_CMAKE_DIR}
+    NAMESPACE rabbitmq::
+    )
 
 install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/librabbitmq.pc

--- a/cmake/rabbitmq-c-config.cmake.in
+++ b/cmake/rabbitmq-c-config.cmake.in
@@ -1,0 +1,4 @@
+@PACKAGE_INIT@
+
+include(${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake)
+check_required_components(rabbitmq-c)

--- a/librabbitmq/CMakeLists.txt
+++ b/librabbitmq/CMakeLists.txt
@@ -131,7 +131,7 @@ if (BUILD_SHARED_LIBS)
         set_target_properties(rabbitmq PROPERTIES VERSION ${RMQ_VERSION} SOVERSION ${RMQ_SOVERSION})
     endif (WIN32)
 
-    install(TARGETS rabbitmq
+    install(TARGETS rabbitmq EXPORT "${targets_export_name}"
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -165,7 +165,7 @@ if (BUILD_STATIC_LIBS)
         set_target_properties(rabbitmq-static PROPERTIES VERSION ${RMQ_VERSION} SOVERSION ${RMQ_SOVERSION} OUTPUT_NAME rabbitmq)
     endif (WIN32)
 
-    install(TARGETS rabbitmq-static
+    install(TARGETS rabbitmq-static EXPORT "${targets_export_name}"
         ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
         )
 


### PR DESCRIPTION
Generating a -config.cmake or Config.cmake lets rabbitmq-c be
discoverable via cmake's `find_package`, and allows easier use in the
vcpkg ecosystem.