### PR TITLE
lib: correct amqp_time_from_now behavior at {0, 0}

### DIFF
--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -760,7 +760,10 @@ int amqp_try_recv(amqp_connection_state_t state) {
       state->last_queued_frame = link;
     }
   }
-  timeout = amqp_time_immediate();
+  int res = amqp_time_s_from_now(&timeout, 0);
+  if (AMQP_STATUS_OK != res) {
+    return res;
+  }
 
   return recv_with_timeout(state, timeout);
 }

--- a/librabbitmq/amqp_time.c
+++ b/librabbitmq/amqp_time.c
@@ -111,10 +111,6 @@ int amqp_time_from_now(amqp_time_t *time, const struct timeval *timeout) {
     *time = amqp_time_infinite();
     return AMQP_STATUS_OK;
   }
-  if (0 == timeout->tv_sec && 0 == timeout->tv_usec) {
-    *time = amqp_time_immediate();
-    return AMQP_STATUS_OK;
-  }
 
   if (timeout->tv_sec < 0 || timeout->tv_usec < 0) {
     return AMQP_STATUS_INVALID_PARAMETER;
@@ -158,12 +154,6 @@ int amqp_time_s_from_now(amqp_time_t *time, int seconds) {
   }
 
   return AMQP_STATUS_OK;
-}
-
-amqp_time_t amqp_time_immediate(void) {
-  amqp_time_t time;
-  time.time_point_ns = 0;
-  return time;
 }
 
 amqp_time_t amqp_time_infinite(void) {

--- a/librabbitmq/amqp_time.h
+++ b/librabbitmq/amqp_time.h
@@ -62,7 +62,6 @@ uint64_t amqp_get_monotonic_timestamp(void);
 
 /* Get a amqp_time_t that is timeout from now.
  * If timeout is NULL, an amqp_time_infinite() is created.
- * If timeout = {0, 0}, an amqp_time_immediate() is created.
  *
  * Returns AMQP_STATUS_OK on success.
  * AMQP_STATUS_INVALID_PARAMETER if timeout is invalid
@@ -79,9 +78,6 @@ int amqp_time_from_now(amqp_time_t *time, const struct timeval *timeout);
  * fails.
  */
 int amqp_time_s_from_now(amqp_time_t *time, int seconds);
-
-/* Create an immediate amqp_time_t */
-amqp_time_t amqp_time_immediate(void);
 
 /* Create an infinite amqp_time_t */
 amqp_time_t amqp_time_infinite(void);


### PR DESCRIPTION
Change behavior of amqp_time_from_now to set to the current timestamp
when a struct timeval of {0, 0} is passed in instead of 0. This better
aligns with how one would expect the function to work.

As a byproduct this corrects an issue where amqp_consume_message would
not return AMQP_STATUS_HEARTBEAT_TIMEOUT when a tv of {0, 0} and the
heartbeat interval had passed.

Fixes #557 in a more concise way.