### PR TITLE
tool: fix issue parsing hostname in --server flag

### DIFF
--- a/tools/common.c
+++ b/tools/common.c
@@ -241,6 +241,7 @@ static void init_connection_info(struct amqp_connection_info *ci) {
           *port_end != 0)
         die("bad server port number in '%s'", amqp_server);
     } else {
+      ci->host = amqp_server;
       ci->port = 5672;
 #if WITH_SSL
       if (amqp_ssl) {


### PR DESCRIPTION
Set both the host and port when a ':' isn't found in in the --server
flag.  The attempted fix in #622 was not complete as the host was not
properly set.

Fixes #621