### PR TITLE
ci: use pre-installed OpenSSL on appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,18 +16,6 @@ configuration:
 
 cache:
   - c:\deps -> appveyor.yml
-  
-# borrowed from https://github.com/FreeTDS/freetds
-install:
-  # xidel (xpath command line tool)
-  - appveyor DownloadFile "https://downloads.sourceforge.net/project/videlibri/Xidel/Xidel 0.9.6/xidel-0.9.6.win32.zip"
-  - 7z x xidel-0.9.6.win32.zip xidel.exe
-  # detect version of Windows OpenSSL binaries published by the Shining Light Productions crew
-  - xidel https://slproweb.com/products/Win32OpenSSL.html --extract "(//td/a[starts-with(@href, '/download') and starts-with(text(), 'Win32 OpenSSL') and ends-with(text(), 'Light')])[1]/translate(substring-before(substring-after(text(), 'Win32 OpenSSL v'), ' Light'), '.', '_')" > openssl_ver.txt
-  - set /P OPENSSL_VER=< openssl_ver.txt
-  # OpenSSL
-  - appveyor DownloadFile https://slproweb.com/download/Win%BITS%OpenSSL-%OPENSSL_VER%.exe	
-  - "Win%BITS%OpenSSL-%OPENSSL_VER%.exe /SP- /SILENT /SUPPRESSMSGBOXES /NORESTART"
 
 before_build:
   - cmake -DBUILD_SHARED_LIBS=ON -DBUILD_STATIC_LIBS=ON -DBUILD_TESTS=ON -DRUN_SYSTEM_TESTS=ON -DENABLE_SSL_SUPPORT=True -G"%GENERATOR%" .
@@ -38,5 +26,5 @@ build:
 
 artifacts:
   - path: librabbitmq\%CONFIGURATION%
-    name: LibRabbit-%BITS%-%OPENSSL_VER%-%CONFIGURATION%.zip
+    name: LibRabbit-%BITS%-%CONFIGURATION%.zip
     type: zip


### PR DESCRIPTION
The current setup is broken, this should fix it, and *ideally* make the CI runs a bit faster.