### PR TITLE
Use cmake TIMESTAMP function

### DIFF
--- a/tools/CMakeLists.txt
+++ b/tools/CMakeLists.txt
@@ -45,9 +45,10 @@ if (BUILD_TOOLS_DOCS)
 
     file(MAKE_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/doc)
     set(XMLTO_DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/doc/man-date.ent)
+    STRING(TIMESTAMP BUILD_DATE "%Y-%m-%d" UTC)
     add_custom_command(
             OUTPUT ${XMLTO_DEPENDS}
-	          COMMAND date +'%Y-%m-%d' > ${XMLTO_DEPENDS}
+	          COMMAND echo ${BUILD_DATE} > ${XMLTO_DEPENDS}
             VERBATIM
             )
 


### PR DESCRIPTION
Use cmake `TIMESTAMP` function
to allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Also use UTC to be independent of timezone.

Note: someone who knows cmake better, could probably further simplify the CMakeLists.txt now