### PR TITLE
Support password protected keys.

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -498,6 +498,15 @@ int amqp_ssl_socket_set_cert(amqp_socket_t *base, const char *cert) {
   return AMQP_STATUS_OK;
 }
 
+void amqp_ssl_socket_set_key_passwd(amqp_socket_t *base, const char *passwd) {
+  struct amqp_ssl_socket_t *self;
+  if (base->klass != &amqp_ssl_socket_class) {
+    amqp_abort("<%p> is not of type amqp_ssl_socket_t", base);
+  }
+  self = (struct amqp_ssl_socket_t *)base;
+  SSL_CTX_set_default_passwd_cb_userdata(self->ctx, (void *)passwd);
+}
+
 void amqp_ssl_socket_set_verify(amqp_socket_t *base, amqp_boolean_t verify) {
   amqp_ssl_socket_set_verify_peer(base, verify);
   amqp_ssl_socket_set_verify_hostname(base, verify);

--- a/librabbitmq/amqp_ssl_socket.h
+++ b/librabbitmq/amqp_ssl_socket.h
@@ -86,12 +86,12 @@ int AMQP_CALL amqp_ssl_socket_set_cacert(amqp_socket_t *self,
                                          const char *cacert);
 
 /**
- * Set the passwrod of key in PEM format.
+ * Set the password of key in PEM format.
  *
  * \param [in,out] self An SSL/TLS socket object.
- * \param [in] passwdw The passwrod of key in PEM format.
+ * \param [in] passwd The password of key in PEM format.
  *
- * \since v0.9.0
+ * \since v0.11.0
  */
 AMQP_PUBLIC_FUNCTION
 void AMQP_CALL amqp_ssl_socket_set_key_passwd(amqp_socket_t *self,

--- a/librabbitmq/amqp_ssl_socket.h
+++ b/librabbitmq/amqp_ssl_socket.h
@@ -86,6 +86,18 @@ int AMQP_CALL amqp_ssl_socket_set_cacert(amqp_socket_t *self,
                                          const char *cacert);
 
 /**
+ * Set the passwrod of key in PEM format.
+ *
+ * \param [in,out] self An SSL/TLS socket object.
+ * \param [in] passwdw The passwrod of key in PEM format.
+ *
+ * \since v0.9.0
+ */
+AMQP_PUBLIC_FUNCTION
+void AMQP_CALL amqp_ssl_socket_set_key_passwd(amqp_socket_t *self,
+                                              const char *passwd);
+
+/**
  * Set the client key.
  *
  * \param [in,out] self An SSL/TLS socket object.


### PR DESCRIPTION
Provide an interface that supports password-protected keys.

Fixed #653 