### PR TITLE
add option to install or not the static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,6 +245,7 @@ endif()
 
 option(BUILD_SHARED_LIBS "Build rabbitmq-c as a shared library" ON)
 option(BUILD_STATIC_LIBS "Build rabbitmq-c as a static library" ON)
+option(INSTALL_STATIC_LIBS "Install rabbitmq-c static library" ON)
 
 option(BUILD_EXAMPLES "Build Examples" ON)
 option(BUILD_TOOLS "Build Tools (requires POPT Library)" ${POPT_FOUND})

--- a/librabbitmq/CMakeLists.txt
+++ b/librabbitmq/CMakeLists.txt
@@ -154,9 +154,11 @@ if (BUILD_STATIC_LIBS)
         set_target_properties(rabbitmq-static PROPERTIES VERSION ${RMQ_VERSION} SOVERSION ${RMQ_SOVERSION} OUTPUT_NAME rabbitmq)
     endif (WIN32)
 
-    install(TARGETS rabbitmq-static EXPORT "${targets_export_name}"
-        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
-        )
+    if (INSTALL_STATIC_LIBS)
+        install(TARGETS rabbitmq-static EXPORT "${targets_export_name}"
+            ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+            )
+    endif (INSTALL_STATIC_LIBS)
 
     if (NOT DEFINED RMQ_LIBRARY_TARGET)
         set(RMQ_LIBRARY_TARGET rabbitmq-static)


### PR DESCRIPTION
This fixes an issue for downstream distribution, where static libraries are discouraged

For now (v0.10.0) we have to use **BUILD_TESTS + BUILD_STATIC_LIBS** to be able to run the test suite
and to exclude `librabbitmq.a `from the package

BUT installed cmake files contain references to the static library, so are (probably) unusable

This trivial fix allow to build but not install the static library, thus cmake files are clean.
