### PR TITLE
cmake: use GenerateExportHeader for AMQP_EXPORT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,4 @@
-cmake_minimum_required(VERSION 3.10...3.18)
-
-if(${CMAKE_VERSION} VERSION_LESS 3.12)
-  cmake_policy(VERSION ${CMAKE_MAJOR_VERSION}.${CMAKE_MINOR_VERSION})
-endif()
+cmake_minimum_required(VERSION 3.12...3.18)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/docs/Doxyfile.in
+++ b/docs/Doxyfile.in
@@ -266,8 +266,7 @@ INCLUDE_PATH           = @CMAKE_CURRENT_SOURCE_DIR@/librabbitmq \
 INCLUDE_FILE_PATTERNS  =
 PREDEFINED             = AMQP_BEGIN_DECLS= \
                          AMQP_END_DECLS= \
-                         AMQP_PUBLIC_FUNCTION= \
-                         AMQP_PUBLIC_VARIABLE= \
+                         AMQP_EXPORT= \
                          AMQP_CALL= \
                          AMQP_DEPRECATED(x)=x
 EXPAND_AS_DEFINED      =

--- a/include/rabbitmq-c/amqp.h
+++ b/include/rabbitmq-c/amqp.h
@@ -34,6 +34,8 @@
  * ***** END LICENSE BLOCK *****
  */
 
+#include <rabbitmq-c/export.h>
+
 #ifndef RABBITMQ_C_RABBITMQ_C_H
 #define RABBITMQ_C_RABBITMQ_C_H
 
@@ -49,84 +51,12 @@
 
 /*
  * \internal
- * Important API decorators:
- *  AMQP_PUBLIC_FUNCTION - a public API function
- *  AMQP_PUBLIC_VARIABLE - a public API external variable
- *  AMQP_CALL - calling convension (used on Win32)
+ * AMQP_CALL - calling convension (used on Win32)
  */
-
-#if defined(_WIN32) && defined(_MSC_VER)
-#if defined(AMQP_BUILD) && !defined(AMQP_STATIC)
-#define AMQP_PUBLIC_FUNCTION __declspec(dllexport)
-#define AMQP_PUBLIC_VARIABLE __declspec(dllexport) extern
-#else
-#define AMQP_PUBLIC_FUNCTION
-#if !defined(AMQP_STATIC)
-#define AMQP_PUBLIC_VARIABLE __declspec(dllimport) extern
-#else
-#define AMQP_PUBLIC_VARIABLE extern
-#endif
-#endif
+#ifdef _WIN32
 #define AMQP_CALL __cdecl
-
-#elif defined(_WIN32) && defined(__BORLANDC__)
-#if defined(AMQP_BUILD) && !defined(AMQP_STATIC)
-#define AMQP_PUBLIC_FUNCTION __declspec(dllexport)
-#define AMQP_PUBLIC_VARIABLE __declspec(dllexport) extern
 #else
-#define AMQP_PUBLIC_FUNCTION
-#if !defined(AMQP_STATIC)
-#define AMQP_PUBLIC_VARIABLE __declspec(dllimport) extern
-#else
-#define AMQP_PUBLIC_VARIABLE extern
-#endif
-#endif
-#define AMQP_CALL __cdecl
-
-#elif defined(_WIN32) && defined(__MINGW32__)
-#if defined(AMQP_BUILD) && !defined(AMQP_STATIC)
-#define AMQP_PUBLIC_FUNCTION __declspec(dllexport)
-#define AMQP_PUBLIC_VARIABLE __declspec(dllexport) extern
-#else
-#define AMQP_PUBLIC_FUNCTION
-#if !defined(AMQP_STATIC)
-#define AMQP_PUBLIC_VARIABLE __declspec(dllimport) extern
-#else
-#define AMQP_PUBLIC_VARIABLE extern
-#endif
-#endif
-#define AMQP_CALL __cdecl
-
-#elif defined(_WIN32) && defined(__CYGWIN__)
-#if defined(AMQP_BUILD) && !defined(AMQP_STATIC)
-#define AMQP_PUBLIC_FUNCTION __declspec(dllexport)
-#define AMQP_PUBLIC_VARIABLE __declspec(dllexport)
-#else
-#define AMQP_PUBLIC_FUNCTION
-#if !defined(AMQP_STATIC)
-#define AMQP_PUBLIC_VARIABLE __declspec(dllimport) extern
-#else
-#define AMQP_PUBLIC_VARIABLE extern
-#endif
-#endif
-#define AMQP_CALL __cdecl
-
-#elif defined(__GNUC__) && __GNUC__ >= 4
-#define AMQP_PUBLIC_FUNCTION __attribute__((visibility("default")))
-#define AMQP_PUBLIC_VARIABLE __attribute__((visibility("default"))) extern
 #define AMQP_CALL
-#else
-#define AMQP_PUBLIC_FUNCTION
-#define AMQP_PUBLIC_VARIABLE extern
-#define AMQP_CALL
-#endif
-
-#if __GNUC__ > 3 || (__GNUC__ == 3 && __GNUC_MINOR__ >= 1)
-#define AMQP_DEPRECATED(function) function __attribute__((__deprecated__))
-#elif defined(_MSC_VER)
-#define AMQP_DEPRECATED(function) __declspec(deprecated) function
-#else
-#define AMQP_DEPRECATED(function)
 #endif
 
 /* Define ssize_t on Win32/64 platforms
@@ -297,7 +227,7 @@ AMQP_BEGIN_DECLS
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 uint32_t AMQP_CALL amqp_version_number(void);
 
 /**
@@ -311,7 +241,7 @@ uint32_t AMQP_CALL amqp_version_number(void);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 char const *AMQP_CALL amqp_version(void);
 
 /**
@@ -796,21 +726,21 @@ AMQP_BEGIN_DECLS
  *
  * \since v0.2
  */
-AMQP_PUBLIC_VARIABLE const amqp_bytes_t amqp_empty_bytes;
+AMQP_EXPORT extern const amqp_bytes_t amqp_empty_bytes;
 
 /**
  * Empty table structure
  *
  * \since v0.2
  */
-AMQP_PUBLIC_VARIABLE const amqp_table_t amqp_empty_table;
+AMQP_EXPORT extern const amqp_table_t amqp_empty_table;
 
 /**
  * Empty table array structure
  *
  * \since v0.2
  */
-AMQP_PUBLIC_VARIABLE const amqp_array_t amqp_empty_array;
+AMQP_EXPORT extern const amqp_array_t amqp_empty_array;
 
 /* Compatibility macros for the above, to avoid the need to update
    code written against earlier versions of librabbitmq. */
@@ -869,7 +799,7 @@ AMQP_PUBLIC_VARIABLE const amqp_array_t amqp_empty_array;
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void AMQP_CALL init_amqp_pool(amqp_pool_t *pool, size_t pagesize);
 
 /**
@@ -892,7 +822,7 @@ void AMQP_CALL init_amqp_pool(amqp_pool_t *pool, size_t pagesize);
  * \since v0.1
  *
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void AMQP_CALL recycle_amqp_pool(amqp_pool_t *pool);
 
 /**
@@ -904,7 +834,7 @@ void AMQP_CALL recycle_amqp_pool(amqp_pool_t *pool);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void AMQP_CALL empty_amqp_pool(amqp_pool_t *pool);
 
 /**
@@ -923,7 +853,7 @@ void AMQP_CALL empty_amqp_pool(amqp_pool_t *pool);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void *AMQP_CALL amqp_pool_alloc(amqp_pool_t *pool, size_t amount);
 
 /**
@@ -945,7 +875,7 @@ void *AMQP_CALL amqp_pool_alloc(amqp_pool_t *pool, size_t amount);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void AMQP_CALL amqp_pool_alloc_bytes(amqp_pool_t *pool, size_t amount,
                                      amqp_bytes_t *output);
 
@@ -967,7 +897,7 @@ void AMQP_CALL amqp_pool_alloc_bytes(amqp_pool_t *pool, size_t amount,
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_bytes_t AMQP_CALL amqp_cstring_bytes(char const *cstr);
 
 /**
@@ -986,7 +916,7 @@ amqp_bytes_t AMQP_CALL amqp_cstring_bytes(char const *cstr);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_bytes_t AMQP_CALL amqp_bytes_malloc_dup(amqp_bytes_t src);
 
 /**
@@ -1003,7 +933,7 @@ amqp_bytes_t AMQP_CALL amqp_bytes_malloc_dup(amqp_bytes_t src);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_bytes_t AMQP_CALL amqp_bytes_malloc(size_t amount);
 
 /**
@@ -1020,7 +950,7 @@ amqp_bytes_t AMQP_CALL amqp_bytes_malloc(size_t amount);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void AMQP_CALL amqp_bytes_free(amqp_bytes_t bytes);
 
 /**
@@ -1035,7 +965,7 @@ void AMQP_CALL amqp_bytes_free(amqp_bytes_t bytes);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_connection_state_t AMQP_CALL amqp_new_connection(void);
 
 /**
@@ -1055,7 +985,7 @@ amqp_connection_state_t AMQP_CALL amqp_new_connection(void);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_get_sockfd(amqp_connection_state_t state);
 
 /**
@@ -1075,8 +1005,8 @@ int AMQP_CALL amqp_get_sockfd(amqp_connection_state_t state);
  *
  * \since v0.1
  */
-AMQP_DEPRECATED(AMQP_PUBLIC_FUNCTION void AMQP_CALL
-                    amqp_set_sockfd(amqp_connection_state_t state, int sockfd));
+AMQP_DEPRECATED_EXPORT void AMQP_CALL
+    amqp_set_sockfd(amqp_connection_state_t state, int sockfd);
 
 /**
  * Tune client side parameters
@@ -1110,7 +1040,7 @@ AMQP_DEPRECATED(AMQP_PUBLIC_FUNCTION void AMQP_CALL
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_tune_connection(amqp_connection_state_t state,
                                    int channel_max, int frame_max,
                                    int heartbeat);
@@ -1126,7 +1056,7 @@ int AMQP_CALL amqp_tune_connection(amqp_connection_state_t state,
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_get_channel_max(amqp_connection_state_t state);
 
 /**
@@ -1140,7 +1070,7 @@ int AMQP_CALL amqp_get_channel_max(amqp_connection_state_t state);
  *
  * \since v0.6
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_get_frame_max(amqp_connection_state_t state);
 
 /**
@@ -1154,7 +1084,7 @@ int AMQP_CALL amqp_get_frame_max(amqp_connection_state_t state);
  *
  * \since v0.6
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_get_heartbeat(amqp_connection_state_t state);
 
 /**
@@ -1174,7 +1104,7 @@ int AMQP_CALL amqp_get_heartbeat(amqp_connection_state_t state);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_destroy_connection(amqp_connection_state_t state);
 
 /**
@@ -1219,7 +1149,7 @@ int AMQP_CALL amqp_destroy_connection(amqp_connection_state_t state);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_handle_input(amqp_connection_state_t state,
                                 amqp_bytes_t received_data,
                                 amqp_frame_t *decoded_frame);
@@ -1241,7 +1171,7 @@ int AMQP_CALL amqp_handle_input(amqp_connection_state_t state,
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_boolean_t AMQP_CALL amqp_release_buffers_ok(amqp_connection_state_t state);
 
 /**
@@ -1268,7 +1198,7 @@ amqp_boolean_t AMQP_CALL amqp_release_buffers_ok(amqp_connection_state_t state);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void AMQP_CALL amqp_release_buffers(amqp_connection_state_t state);
 
 /**
@@ -1288,7 +1218,7 @@ void AMQP_CALL amqp_release_buffers(amqp_connection_state_t state);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void AMQP_CALL amqp_maybe_release_buffers(amqp_connection_state_t state);
 
 /**
@@ -1311,7 +1241,7 @@ void AMQP_CALL amqp_maybe_release_buffers(amqp_connection_state_t state);
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void AMQP_CALL amqp_maybe_release_buffers_on_channel(
     amqp_connection_state_t state, amqp_channel_t channel);
 
@@ -1336,7 +1266,7 @@ void AMQP_CALL amqp_maybe_release_buffers_on_channel(
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_send_frame(amqp_connection_state_t state,
                               amqp_frame_t const *frame);
 
@@ -1352,7 +1282,7 @@ int AMQP_CALL amqp_send_frame(amqp_connection_state_t state,
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_table_entry_cmp(void const *entry1, void const *entry2);
 
 /**
@@ -1382,7 +1312,7 @@ int AMQP_CALL amqp_table_entry_cmp(void const *entry1, void const *entry2);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_open_socket(char const *hostname, int portnumber);
 
 /**
@@ -1406,7 +1336,7 @@ int AMQP_CALL amqp_open_socket(char const *hostname, int portnumber);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_send_header(amqp_connection_state_t state);
 
 /**
@@ -1425,7 +1355,7 @@ int AMQP_CALL amqp_send_header(amqp_connection_state_t state);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_boolean_t AMQP_CALL amqp_frames_enqueued(amqp_connection_state_t state);
 
 /**
@@ -1479,7 +1409,7 @@ amqp_boolean_t AMQP_CALL amqp_frames_enqueued(amqp_connection_state_t state);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_simple_wait_frame(amqp_connection_state_t state,
                                      amqp_frame_t *decoded_frame);
 
@@ -1546,7 +1476,7 @@ int AMQP_CALL amqp_simple_wait_frame(amqp_connection_state_t state,
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_simple_wait_frame_noblock(amqp_connection_state_t state,
                                              amqp_frame_t *decoded_frame,
                                              const struct timeval *tv);
@@ -1592,7 +1522,7 @@ int AMQP_CALL amqp_simple_wait_frame_noblock(amqp_connection_state_t state,
  * \since v0.1
  */
 
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_simple_wait_method(amqp_connection_state_t state,
                                       amqp_channel_t expected_channel,
                                       amqp_method_number_t expected_method,
@@ -1624,7 +1554,7 @@ int AMQP_CALL amqp_simple_wait_method(amqp_connection_state_t state,
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_send_method(amqp_connection_state_t state,
                                amqp_channel_t channel, amqp_method_number_t id,
                                void *decoded);
@@ -1661,7 +1591,7 @@ int AMQP_CALL amqp_send_method(amqp_connection_state_t state,
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_rpc_reply_t AMQP_CALL amqp_simple_rpc(
     amqp_connection_state_t state, amqp_channel_t channel,
     amqp_method_number_t request_id, amqp_method_number_t *expected_reply_ids,
@@ -1681,7 +1611,7 @@ amqp_rpc_reply_t AMQP_CALL amqp_simple_rpc(
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void *AMQP_CALL amqp_simple_rpc_decoded(amqp_connection_state_t state,
                                         amqp_channel_t channel,
                                         amqp_method_number_t request_id,
@@ -1727,7 +1657,7 @@ void *AMQP_CALL amqp_simple_rpc_decoded(amqp_connection_state_t state,
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_rpc_reply_t AMQP_CALL amqp_get_rpc_reply(amqp_connection_state_t state);
 
 /**
@@ -1787,7 +1717,7 @@ amqp_rpc_reply_t AMQP_CALL amqp_get_rpc_reply(amqp_connection_state_t state);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_rpc_reply_t AMQP_CALL amqp_login(amqp_connection_state_t state,
                                       char const *vhost, int channel_max,
                                       int frame_max, int heartbeat,
@@ -1853,7 +1783,7 @@ amqp_rpc_reply_t AMQP_CALL amqp_login(amqp_connection_state_t state,
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_rpc_reply_t AMQP_CALL amqp_login_with_properties(
     amqp_connection_state_t state, char const *vhost, int channel_max,
     int frame_max, int heartbeat, const amqp_table_t *properties,
@@ -1906,7 +1836,7 @@ struct amqp_basic_properties_t_;
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_basic_publish(
     amqp_connection_state_t state, amqp_channel_t channel,
     amqp_bytes_t exchange, amqp_bytes_t routing_key, amqp_boolean_t mandatory,
@@ -1924,7 +1854,7 @@ int AMQP_CALL amqp_basic_publish(
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_rpc_reply_t AMQP_CALL amqp_channel_close(amqp_connection_state_t state,
                                               amqp_channel_t channel, int code);
 
@@ -1942,7 +1872,7 @@ amqp_rpc_reply_t AMQP_CALL amqp_channel_close(amqp_connection_state_t state,
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_rpc_reply_t AMQP_CALL amqp_connection_close(amqp_connection_state_t state,
                                                  int code);
 
@@ -1962,7 +1892,7 @@ amqp_rpc_reply_t AMQP_CALL amqp_connection_close(amqp_connection_state_t state,
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_basic_ack(amqp_connection_state_t state,
                              amqp_channel_t channel, uint64_t delivery_tag,
                              amqp_boolean_t multiple);
@@ -1983,7 +1913,7 @@ int AMQP_CALL amqp_basic_ack(amqp_connection_state_t state,
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_rpc_reply_t AMQP_CALL amqp_basic_get(amqp_connection_state_t state,
                                           amqp_channel_t channel,
                                           amqp_bytes_t queue,
@@ -2005,7 +1935,7 @@ amqp_rpc_reply_t AMQP_CALL amqp_basic_get(amqp_connection_state_t state,
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_basic_reject(amqp_connection_state_t state,
                                 amqp_channel_t channel, uint64_t delivery_tag,
                                 amqp_boolean_t requeue);
@@ -2029,7 +1959,7 @@ int AMQP_CALL amqp_basic_reject(amqp_connection_state_t state,
  *
  * \since v0.5.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_basic_nack(amqp_connection_state_t state,
                               amqp_channel_t channel, uint64_t delivery_tag,
                               amqp_boolean_t multiple, amqp_boolean_t requeue);
@@ -2045,7 +1975,7 @@ int AMQP_CALL amqp_basic_nack(amqp_connection_state_t state,
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_boolean_t AMQP_CALL amqp_data_in_buffer(amqp_connection_state_t state);
 
 /**
@@ -2063,8 +1993,7 @@ amqp_boolean_t AMQP_CALL amqp_data_in_buffer(amqp_connection_state_t state);
  *
  * \since v0.1
  */
-AMQP_DEPRECATED(
-    AMQP_PUBLIC_FUNCTION char *AMQP_CALL amqp_error_string(int err));
+AMQP_DEPRECATED_EXPORT char *AMQP_CALL amqp_error_string(int err);
 
 /**
  * Get the error string for the given error code.
@@ -2077,7 +2006,7 @@ AMQP_DEPRECATED(
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 const char *AMQP_CALL amqp_error_string2(int err);
 
 /**
@@ -2100,7 +2029,7 @@ const char *AMQP_CALL amqp_error_string2(int err);
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_decode_table(amqp_bytes_t encoded, amqp_pool_t *pool,
                                 amqp_table_t *output, size_t *offset);
 
@@ -2123,7 +2052,7 @@ int AMQP_CALL amqp_decode_table(amqp_bytes_t encoded, amqp_pool_t *pool,
  *
  * \since v0.1
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_encode_table(amqp_bytes_t encoded, amqp_table_t *input,
                                 size_t *offset);
 
@@ -2145,7 +2074,7 @@ int AMQP_CALL amqp_encode_table(amqp_bytes_t encoded, amqp_table_t *input,
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_table_clone(const amqp_table_t *original,
                                amqp_table_t *clone, amqp_pool_t *pool);
 
@@ -2179,7 +2108,7 @@ typedef struct amqp_message_t_ {
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_rpc_reply_t AMQP_CALL amqp_read_message(amqp_connection_state_t state,
                                              amqp_channel_t channel,
                                              amqp_message_t *message,
@@ -2192,7 +2121,7 @@ amqp_rpc_reply_t AMQP_CALL amqp_read_message(amqp_connection_state_t state,
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void AMQP_CALL amqp_destroy_message(amqp_message_t *message);
 
 /**
@@ -2243,7 +2172,7 @@ typedef struct amqp_envelope_t_ {
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_rpc_reply_t AMQP_CALL amqp_consume_message(amqp_connection_state_t state,
                                                 amqp_envelope_t *envelope,
                                                 const struct timeval *timeout,
@@ -2257,7 +2186,7 @@ amqp_rpc_reply_t AMQP_CALL amqp_consume_message(amqp_connection_state_t state,
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void AMQP_CALL amqp_destroy_envelope(amqp_envelope_t *envelope);
 
 /**
@@ -2292,7 +2221,7 @@ struct amqp_connection_info {
  *
  * \since v0.2
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void AMQP_CALL
     amqp_default_connection_info(struct amqp_connection_info *parsed);
 
@@ -2322,7 +2251,7 @@ void AMQP_CALL
  *
  * \since v0.2
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_parse_url(char *url, struct amqp_connection_info *parsed);
 
 /* socket API */
@@ -2343,7 +2272,7 @@ int AMQP_CALL amqp_parse_url(char *url, struct amqp_connection_info *parsed);
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_socket_open(amqp_socket_t *self, const char *host, int port);
 
 /**
@@ -2364,7 +2293,7 @@ int AMQP_CALL amqp_socket_open(amqp_socket_t *self, const char *host, int port);
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_socket_open_noblock(amqp_socket_t *self, const char *host,
                                        int port, const struct timeval *timeout);
 
@@ -2382,7 +2311,7 @@ int AMQP_CALL amqp_socket_open_noblock(amqp_socket_t *self, const char *host,
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_socket_get_sockfd(amqp_socket_t *self);
 
 /**
@@ -2393,7 +2322,7 @@ int AMQP_CALL amqp_socket_get_sockfd(amqp_socket_t *self);
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_socket_t *AMQP_CALL amqp_get_socket(amqp_connection_state_t state);
 
 /**
@@ -2406,7 +2335,7 @@ amqp_socket_t *AMQP_CALL amqp_get_socket(amqp_connection_state_t state);
  *
  * \since v0.5.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_table_t *AMQP_CALL
     amqp_get_server_properties(amqp_connection_state_t state);
 
@@ -2422,7 +2351,7 @@ amqp_table_t *AMQP_CALL
  *
  * \since v0.7.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_table_t *AMQP_CALL
     amqp_get_client_properties(amqp_connection_state_t state);
 
@@ -2445,7 +2374,7 @@ amqp_table_t *AMQP_CALL
  *
  * \since v0.9.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 struct timeval *AMQP_CALL
     amqp_get_handshake_timeout(amqp_connection_state_t state);
 
@@ -2472,7 +2401,7 @@ struct timeval *AMQP_CALL
  *
  * \since v0.9.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_set_handshake_timeout(amqp_connection_state_t state,
                                          const struct timeval *timeout);
 
@@ -2501,7 +2430,7 @@ int AMQP_CALL amqp_set_handshake_timeout(amqp_connection_state_t state,
  *
  * \since v0.9.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 struct timeval *AMQP_CALL amqp_get_rpc_timeout(amqp_connection_state_t state);
 
 /**
@@ -2530,7 +2459,7 @@ struct timeval *AMQP_CALL amqp_get_rpc_timeout(amqp_connection_state_t state);
  *
  * \since v0.9.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_set_rpc_timeout(amqp_connection_state_t state,
                                    const struct timeval *timeout);
 

--- a/include/rabbitmq-c/framing.h
+++ b/include/rabbitmq-c/framing.h
@@ -39,6 +39,7 @@
 #define RABBITMQ_C_FRAMING_H
 
 #include <rabbitmq-c/amqp.h>
+#include <rabbitmq-c/export.h>
 
 AMQP_BEGIN_DECLS
 
@@ -83,7 +84,7 @@ AMQP_BEGIN_DECLS
  * @returns string describing the constant. String is managed by
  *           the library and should not be free()'d by the program
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 char const *AMQP_CALL amqp_constant_name(int constantNumber);
 
 /**
@@ -95,7 +96,7 @@ char const *AMQP_CALL amqp_constant_name(int constantNumber);
  * @param [in] constantNumber the error constant
  * @returns true if its a hard error, false otherwise
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_boolean_t AMQP_CALL amqp_constant_is_hard_error(int constantNumber);
 
 /**
@@ -105,7 +106,7 @@ amqp_boolean_t AMQP_CALL amqp_constant_is_hard_error(int constantNumber);
  * @returns method name string. String is managed by the library
  *           and should not be freed()'d by the program
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 char const *AMQP_CALL amqp_method_name(amqp_method_number_t methodNumber);
 
 /**
@@ -117,7 +118,7 @@ char const *AMQP_CALL amqp_method_name(amqp_method_number_t methodNumber);
  * @param [in] methodNumber the method number
  * @returns true if method has content, false otherwise
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_boolean_t AMQP_CALL
     amqp_method_has_content(amqp_method_number_t methodNumber);
 
@@ -130,7 +131,7 @@ amqp_boolean_t AMQP_CALL
  * @param [out] decoded pointer to the decoded method struct
  * @returns 0 on success, an error code otherwise
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_decode_method(amqp_method_number_t methodNumber,
                                  amqp_pool_t *pool, amqp_bytes_t encoded,
                                  void **decoded);
@@ -144,7 +145,7 @@ int AMQP_CALL amqp_decode_method(amqp_method_number_t methodNumber,
  * @param [out] decoded pointer to the decoded properties struct
  * @returns 0 on success, an error code otherwise
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_decode_properties(uint16_t class_id, amqp_pool_t *pool,
                                      amqp_bytes_t encoded, void **decoded);
 
@@ -158,7 +159,7 @@ int AMQP_CALL amqp_decode_properties(uint16_t class_id, amqp_pool_t *pool,
  *              to hold the encoded method, an error code will be returned.
  * @returns 0 on success, an error code otherwise.
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_encode_method(amqp_method_number_t methodNumber,
                                  void *decoded, amqp_bytes_t encoded);
 
@@ -173,7 +174,7 @@ int AMQP_CALL amqp_encode_method(amqp_method_number_t methodNumber,
  *              an error code will be returned
  * @returns 0 on success, an error code otherwise.
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_encode_properties(uint16_t class_id, void *decoded,
                                      amqp_bytes_t encoded);
 
@@ -886,7 +887,7 @@ typedef struct amqp_confirm_properties_t_ {
  * @param [in] channel the channel to do the RPC on
  * @returns amqp_channel_open_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_channel_open_ok_t *AMQP_CALL
     amqp_channel_open(amqp_connection_state_t state, amqp_channel_t channel);
 /**
@@ -897,7 +898,7 @@ amqp_channel_open_ok_t *AMQP_CALL
  * @param [in] active active
  * @returns amqp_channel_flow_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_channel_flow_ok_t *AMQP_CALL
     amqp_channel_flow(amqp_connection_state_t state, amqp_channel_t channel,
                       amqp_boolean_t active);
@@ -915,7 +916,7 @@ amqp_channel_flow_ok_t *AMQP_CALL
  * @param [in] arguments arguments
  * @returns amqp_exchange_declare_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_exchange_declare_ok_t *AMQP_CALL amqp_exchange_declare(
     amqp_connection_state_t state, amqp_channel_t channel,
     amqp_bytes_t exchange, amqp_bytes_t type, amqp_boolean_t passive,
@@ -930,7 +931,7 @@ amqp_exchange_declare_ok_t *AMQP_CALL amqp_exchange_declare(
  * @param [in] if_unused if_unused
  * @returns amqp_exchange_delete_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_exchange_delete_ok_t *AMQP_CALL
     amqp_exchange_delete(amqp_connection_state_t state, amqp_channel_t channel,
                          amqp_bytes_t exchange, amqp_boolean_t if_unused);
@@ -945,7 +946,7 @@ amqp_exchange_delete_ok_t *AMQP_CALL
  * @param [in] arguments arguments
  * @returns amqp_exchange_bind_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_exchange_bind_ok_t *AMQP_CALL
     amqp_exchange_bind(amqp_connection_state_t state, amqp_channel_t channel,
                        amqp_bytes_t destination, amqp_bytes_t source,
@@ -961,7 +962,7 @@ amqp_exchange_bind_ok_t *AMQP_CALL
  * @param [in] arguments arguments
  * @returns amqp_exchange_unbind_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_exchange_unbind_ok_t *AMQP_CALL
     amqp_exchange_unbind(amqp_connection_state_t state, amqp_channel_t channel,
                          amqp_bytes_t destination, amqp_bytes_t source,
@@ -979,7 +980,7 @@ amqp_exchange_unbind_ok_t *AMQP_CALL
  * @param [in] arguments arguments
  * @returns amqp_queue_declare_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_queue_declare_ok_t *AMQP_CALL amqp_queue_declare(
     amqp_connection_state_t state, amqp_channel_t channel, amqp_bytes_t queue,
     amqp_boolean_t passive, amqp_boolean_t durable, amqp_boolean_t exclusive,
@@ -995,7 +996,7 @@ amqp_queue_declare_ok_t *AMQP_CALL amqp_queue_declare(
  * @param [in] arguments arguments
  * @returns amqp_queue_bind_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_queue_bind_ok_t *AMQP_CALL amqp_queue_bind(
     amqp_connection_state_t state, amqp_channel_t channel, amqp_bytes_t queue,
     amqp_bytes_t exchange, amqp_bytes_t routing_key, amqp_table_t arguments);
@@ -1007,7 +1008,7 @@ amqp_queue_bind_ok_t *AMQP_CALL amqp_queue_bind(
  * @param [in] queue queue
  * @returns amqp_queue_purge_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_queue_purge_ok_t *AMQP_CALL amqp_queue_purge(amqp_connection_state_t state,
                                                   amqp_channel_t channel,
                                                   amqp_bytes_t queue);
@@ -1021,7 +1022,7 @@ amqp_queue_purge_ok_t *AMQP_CALL amqp_queue_purge(amqp_connection_state_t state,
  * @param [in] if_empty if_empty
  * @returns amqp_queue_delete_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_queue_delete_ok_t *AMQP_CALL amqp_queue_delete(
     amqp_connection_state_t state, amqp_channel_t channel, amqp_bytes_t queue,
     amqp_boolean_t if_unused, amqp_boolean_t if_empty);
@@ -1036,7 +1037,7 @@ amqp_queue_delete_ok_t *AMQP_CALL amqp_queue_delete(
  * @param [in] arguments arguments
  * @returns amqp_queue_unbind_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_queue_unbind_ok_t *AMQP_CALL amqp_queue_unbind(
     amqp_connection_state_t state, amqp_channel_t channel, amqp_bytes_t queue,
     amqp_bytes_t exchange, amqp_bytes_t routing_key, amqp_table_t arguments);
@@ -1050,7 +1051,7 @@ amqp_queue_unbind_ok_t *AMQP_CALL amqp_queue_unbind(
  * @param [in] global global
  * @returns amqp_basic_qos_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_basic_qos_ok_t *AMQP_CALL amqp_basic_qos(amqp_connection_state_t state,
                                               amqp_channel_t channel,
                                               uint32_t prefetch_size,
@@ -1069,7 +1070,7 @@ amqp_basic_qos_ok_t *AMQP_CALL amqp_basic_qos(amqp_connection_state_t state,
  * @param [in] arguments arguments
  * @returns amqp_basic_consume_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_basic_consume_ok_t *AMQP_CALL amqp_basic_consume(
     amqp_connection_state_t state, amqp_channel_t channel, amqp_bytes_t queue,
     amqp_bytes_t consumer_tag, amqp_boolean_t no_local, amqp_boolean_t no_ack,
@@ -1082,7 +1083,7 @@ amqp_basic_consume_ok_t *AMQP_CALL amqp_basic_consume(
  * @param [in] consumer_tag consumer_tag
  * @returns amqp_basic_cancel_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_basic_cancel_ok_t *AMQP_CALL
     amqp_basic_cancel(amqp_connection_state_t state, amqp_channel_t channel,
                       amqp_bytes_t consumer_tag);
@@ -1094,7 +1095,7 @@ amqp_basic_cancel_ok_t *AMQP_CALL
  * @param [in] requeue requeue
  * @returns amqp_basic_recover_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_basic_recover_ok_t *AMQP_CALL
     amqp_basic_recover(amqp_connection_state_t state, amqp_channel_t channel,
                        amqp_boolean_t requeue);
@@ -1105,7 +1106,7 @@ amqp_basic_recover_ok_t *AMQP_CALL
  * @param [in] channel the channel to do the RPC on
  * @returns amqp_tx_select_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_tx_select_ok_t *AMQP_CALL amqp_tx_select(amqp_connection_state_t state,
                                               amqp_channel_t channel);
 /**
@@ -1115,7 +1116,7 @@ amqp_tx_select_ok_t *AMQP_CALL amqp_tx_select(amqp_connection_state_t state,
  * @param [in] channel the channel to do the RPC on
  * @returns amqp_tx_commit_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_tx_commit_ok_t *AMQP_CALL amqp_tx_commit(amqp_connection_state_t state,
                                               amqp_channel_t channel);
 /**
@@ -1125,7 +1126,7 @@ amqp_tx_commit_ok_t *AMQP_CALL amqp_tx_commit(amqp_connection_state_t state,
  * @param [in] channel the channel to do the RPC on
  * @returns amqp_tx_rollback_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_tx_rollback_ok_t *AMQP_CALL amqp_tx_rollback(amqp_connection_state_t state,
                                                   amqp_channel_t channel);
 /**
@@ -1135,7 +1136,7 @@ amqp_tx_rollback_ok_t *AMQP_CALL amqp_tx_rollback(amqp_connection_state_t state,
  * @param [in] channel the channel to do the RPC on
  * @returns amqp_confirm_select_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_confirm_select_ok_t *AMQP_CALL
     amqp_confirm_select(amqp_connection_state_t state, amqp_channel_t channel);
 

--- a/include/rabbitmq-c/ssl_socket.h
+++ b/include/rabbitmq-c/ssl_socket.h
@@ -29,6 +29,7 @@
 #define RABBITMQ_C_SSL_SOCKET_H
 
 #include <rabbitmq-c/amqp.h>
+#include <rabbitmq-c/export.h>
 
 AMQP_BEGIN_DECLS
 
@@ -54,7 +55,7 @@ AMQP_BEGIN_DECLS
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_socket_t *AMQP_CALL amqp_ssl_socket_new(amqp_connection_state_t state);
 
 /**
@@ -67,7 +68,7 @@ amqp_socket_t *AMQP_CALL amqp_ssl_socket_new(amqp_connection_state_t state);
  *
  * \since v0.9.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void *AMQP_CALL amqp_ssl_socket_get_context(amqp_socket_t *self);
 
 /**
@@ -81,7 +82,7 @@ void *AMQP_CALL amqp_ssl_socket_get_context(amqp_socket_t *self);
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_ssl_socket_set_cacert(amqp_socket_t *self,
                                          const char *cacert);
 
@@ -93,7 +94,7 @@ int AMQP_CALL amqp_ssl_socket_set_cacert(amqp_socket_t *self,
  *
  * \since v0.11.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void AMQP_CALL amqp_ssl_socket_set_key_passwd(amqp_socket_t *self,
                                               const char *passwd);
 
@@ -109,7 +110,7 @@ void AMQP_CALL amqp_ssl_socket_set_key_passwd(amqp_socket_t *self,
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_ssl_socket_set_key(amqp_socket_t *self, const char *cert,
                                       const char *key);
 
@@ -127,7 +128,7 @@ int AMQP_CALL amqp_ssl_socket_set_key(amqp_socket_t *self, const char *cert,
  *
  * \since v0.11.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_ssl_socket_set_key_engine(amqp_socket_t *self,
                                              const char *cert, const char *key);
 
@@ -144,7 +145,7 @@ int AMQP_CALL amqp_ssl_socket_set_key_engine(amqp_socket_t *self,
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_ssl_socket_set_key_buffer(amqp_socket_t *self,
                                              const char *cert, const void *key,
                                              size_t n);
@@ -164,8 +165,8 @@ int AMQP_CALL amqp_ssl_socket_set_key_buffer(amqp_socket_t *self,
  *
  * \since v0.4.0
  */
-AMQP_DEPRECATED(AMQP_PUBLIC_FUNCTION void AMQP_CALL amqp_ssl_socket_set_verify(
-    amqp_socket_t *self, amqp_boolean_t verify));
+AMQP_DEPRECATED_EXPORT void AMQP_CALL
+    amqp_ssl_socket_set_verify(amqp_socket_t *self, amqp_boolean_t verify);
 
 /**
  * Enable or disable peer verification.
@@ -178,7 +179,7 @@ AMQP_DEPRECATED(AMQP_PUBLIC_FUNCTION void AMQP_CALL amqp_ssl_socket_set_verify(
  *
  * \since v0.8.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void AMQP_CALL amqp_ssl_socket_set_verify_peer(amqp_socket_t *self,
                                                amqp_boolean_t verify);
 
@@ -191,7 +192,7 @@ void AMQP_CALL amqp_ssl_socket_set_verify_peer(amqp_socket_t *self,
  *
  * \since v0.8.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void AMQP_CALL amqp_ssl_socket_set_verify_hostname(amqp_socket_t *self,
                                                    amqp_boolean_t verify);
 
@@ -218,7 +219,7 @@ typedef enum {
  *
  * \since v0.8.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_ssl_socket_set_ssl_versions(amqp_socket_t *self,
                                                amqp_tls_version_t min,
                                                amqp_tls_version_t max);
@@ -246,7 +247,7 @@ int AMQP_CALL amqp_ssl_socket_set_ssl_versions(amqp_socket_t *self,
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void AMQP_CALL amqp_set_initialize_ssl_library(amqp_boolean_t do_initialize);
 
 /**
@@ -264,7 +265,7 @@ void AMQP_CALL amqp_set_initialize_ssl_library(amqp_boolean_t do_initialize);
  *
  * \since v0.9.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_initialize_ssl_library(void);
 
 /**
@@ -280,7 +281,7 @@ int AMQP_CALL amqp_initialize_ssl_library(void);
  *
  * \since v0.11.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int amqp_set_ssl_engine(const char *engine);
 
 /**
@@ -290,7 +291,7 @@ int amqp_set_ssl_engine(const char *engine);
  *
  * \since v0.9.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int AMQP_CALL amqp_uninitialize_ssl_library(void);
 
 AMQP_END_DECLS

--- a/include/rabbitmq-c/tcp_socket.h
+++ b/include/rabbitmq-c/tcp_socket.h
@@ -33,6 +33,7 @@
 #define RABBITMQ_C_TCP_SOCKET_H
 
 #include <rabbitmq-c/amqp.h>
+#include <rabbitmq-c/export.h>
 
 AMQP_BEGIN_DECLS
 
@@ -45,7 +46,7 @@ AMQP_BEGIN_DECLS
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_socket_t *AMQP_CALL amqp_tcp_socket_new(amqp_connection_state_t state);
 
 /**
@@ -60,7 +61,7 @@ amqp_socket_t *AMQP_CALL amqp_tcp_socket_new(amqp_connection_state_t state);
  *
  * \since v0.4.0
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 void AMQP_CALL amqp_tcp_socket_set_sockfd(amqp_socket_t *self, int sockfd);
 
 AMQP_END_DECLS

--- a/librabbitmq/CMakeLists.txt
+++ b/librabbitmq/CMakeLists.txt
@@ -56,6 +56,7 @@ include_directories(${LIBRABBITMQ_INCLUDE_DIRS})
 
 set(LIBRABBITMQ_INCLUDE_DIRS
 	${CMAKE_CURRENT_SOURCE_DIR}/../include
+  ${CMAKE_CURRENT_BINARY_DIR}
 	PARENT_SCOPE)
 
 add_definitions(-DHAVE_CONFIG_H)
@@ -162,6 +163,14 @@ if (BUILD_STATIC_LIBS)
     endif ()
 endif (BUILD_STATIC_LIBS)
 
+include(GenerateExportHeader)
+generate_export_header(${RMQ_LIBRARY_TARGET}
+  BASE_NAME AMQP
+  EXPORT_FILE_NAME ${CMAKE_CURRENT_BINARY_DIR}/rabbitmq-c/export.h
+  STATIC_DEFINE AMQP_STATIC
+  INCLUDE_GUARD_NAME RABBITMQ_C_EXPORT_H
+)
+
 install(FILES
   ../include/amqp.h
   ../include/amqp_framing.h
@@ -174,6 +183,7 @@ install(FILES
   ../include/rabbitmq-c/framing.h
   ../include/rabbitmq-c/tcp_socket.h
   ${AMQP_SSL_SOCKET_H_PATH}
+  ${CMAKE_CURRENT_BINARY_DIR}/rabbitmq-c/export.h
   DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/rabbitmq-c
 )
 

--- a/librabbitmq/amqp_framing.c
+++ b/librabbitmq/amqp_framing.c
@@ -2440,7 +2440,7 @@ int amqp_encode_properties(uint16_t class_id, void *decoded,
  * @param [in] channel the channel to do the RPC on
  * @returns amqp_channel_open_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_channel_open_ok_t *AMQP_CALL
     amqp_channel_open(amqp_connection_state_t state, amqp_channel_t channel) {
   amqp_channel_open_t req;
@@ -2458,7 +2458,7 @@ amqp_channel_open_ok_t *AMQP_CALL
  * @param [in] active active
  * @returns amqp_channel_flow_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_channel_flow_ok_t *AMQP_CALL
     amqp_channel_flow(amqp_connection_state_t state, amqp_channel_t channel,
                       amqp_boolean_t active) {
@@ -2483,7 +2483,7 @@ amqp_channel_flow_ok_t *AMQP_CALL
  * @param [in] arguments arguments
  * @returns amqp_exchange_declare_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_exchange_declare_ok_t *AMQP_CALL amqp_exchange_declare(
     amqp_connection_state_t state, amqp_channel_t channel,
     amqp_bytes_t exchange, amqp_bytes_t type, amqp_boolean_t passive,
@@ -2513,7 +2513,7 @@ amqp_exchange_declare_ok_t *AMQP_CALL amqp_exchange_declare(
  * @param [in] if_unused if_unused
  * @returns amqp_exchange_delete_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_exchange_delete_ok_t *AMQP_CALL
     amqp_exchange_delete(amqp_connection_state_t state, amqp_channel_t channel,
                          amqp_bytes_t exchange, amqp_boolean_t if_unused) {
@@ -2538,7 +2538,7 @@ amqp_exchange_delete_ok_t *AMQP_CALL
  * @param [in] arguments arguments
  * @returns amqp_exchange_bind_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_exchange_bind_ok_t *AMQP_CALL
     amqp_exchange_bind(amqp_connection_state_t state, amqp_channel_t channel,
                        amqp_bytes_t destination, amqp_bytes_t source,
@@ -2566,7 +2566,7 @@ amqp_exchange_bind_ok_t *AMQP_CALL
  * @param [in] arguments arguments
  * @returns amqp_exchange_unbind_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_exchange_unbind_ok_t *AMQP_CALL
     amqp_exchange_unbind(amqp_connection_state_t state, amqp_channel_t channel,
                          amqp_bytes_t destination, amqp_bytes_t source,
@@ -2596,7 +2596,7 @@ amqp_exchange_unbind_ok_t *AMQP_CALL
  * @param [in] arguments arguments
  * @returns amqp_queue_declare_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_queue_declare_ok_t *AMQP_CALL amqp_queue_declare(
     amqp_connection_state_t state, amqp_channel_t channel, amqp_bytes_t queue,
     amqp_boolean_t passive, amqp_boolean_t durable, amqp_boolean_t exclusive,
@@ -2626,7 +2626,7 @@ amqp_queue_declare_ok_t *AMQP_CALL amqp_queue_declare(
  * @param [in] arguments arguments
  * @returns amqp_queue_bind_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_queue_bind_ok_t *AMQP_CALL amqp_queue_bind(
     amqp_connection_state_t state, amqp_channel_t channel, amqp_bytes_t queue,
     amqp_bytes_t exchange, amqp_bytes_t routing_key, amqp_table_t arguments) {
@@ -2650,7 +2650,7 @@ amqp_queue_bind_ok_t *AMQP_CALL amqp_queue_bind(
  * @param [in] queue queue
  * @returns amqp_queue_purge_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_queue_purge_ok_t *AMQP_CALL amqp_queue_purge(amqp_connection_state_t state,
                                                   amqp_channel_t channel,
                                                   amqp_bytes_t queue) {
@@ -2673,7 +2673,7 @@ amqp_queue_purge_ok_t *AMQP_CALL amqp_queue_purge(amqp_connection_state_t state,
  * @param [in] if_empty if_empty
  * @returns amqp_queue_delete_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_queue_delete_ok_t *AMQP_CALL amqp_queue_delete(
     amqp_connection_state_t state, amqp_channel_t channel, amqp_bytes_t queue,
     amqp_boolean_t if_unused, amqp_boolean_t if_empty) {
@@ -2699,7 +2699,7 @@ amqp_queue_delete_ok_t *AMQP_CALL amqp_queue_delete(
  * @param [in] arguments arguments
  * @returns amqp_queue_unbind_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_queue_unbind_ok_t *AMQP_CALL amqp_queue_unbind(
     amqp_connection_state_t state, amqp_channel_t channel, amqp_bytes_t queue,
     amqp_bytes_t exchange, amqp_bytes_t routing_key, amqp_table_t arguments) {
@@ -2724,7 +2724,7 @@ amqp_queue_unbind_ok_t *AMQP_CALL amqp_queue_unbind(
  * @param [in] global global
  * @returns amqp_basic_qos_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_basic_qos_ok_t *AMQP_CALL amqp_basic_qos(amqp_connection_state_t state,
                                               amqp_channel_t channel,
                                               uint32_t prefetch_size,
@@ -2752,7 +2752,7 @@ amqp_basic_qos_ok_t *AMQP_CALL amqp_basic_qos(amqp_connection_state_t state,
  * @param [in] arguments arguments
  * @returns amqp_basic_consume_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_basic_consume_ok_t *AMQP_CALL amqp_basic_consume(
     amqp_connection_state_t state, amqp_channel_t channel, amqp_bytes_t queue,
     amqp_bytes_t consumer_tag, amqp_boolean_t no_local, amqp_boolean_t no_ack,
@@ -2779,7 +2779,7 @@ amqp_basic_consume_ok_t *AMQP_CALL amqp_basic_consume(
  * @param [in] consumer_tag consumer_tag
  * @returns amqp_basic_cancel_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_basic_cancel_ok_t *AMQP_CALL
     amqp_basic_cancel(amqp_connection_state_t state, amqp_channel_t channel,
                       amqp_bytes_t consumer_tag) {
@@ -2799,7 +2799,7 @@ amqp_basic_cancel_ok_t *AMQP_CALL
  * @param [in] requeue requeue
  * @returns amqp_basic_recover_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_basic_recover_ok_t *AMQP_CALL
     amqp_basic_recover(amqp_connection_state_t state, amqp_channel_t channel,
                        amqp_boolean_t requeue) {
@@ -2817,7 +2817,7 @@ amqp_basic_recover_ok_t *AMQP_CALL
  * @param [in] channel the channel to do the RPC on
  * @returns amqp_tx_select_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_tx_select_ok_t *AMQP_CALL amqp_tx_select(amqp_connection_state_t state,
                                               amqp_channel_t channel) {
   amqp_tx_select_t req;
@@ -2833,7 +2833,7 @@ amqp_tx_select_ok_t *AMQP_CALL amqp_tx_select(amqp_connection_state_t state,
  * @param [in] channel the channel to do the RPC on
  * @returns amqp_tx_commit_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_tx_commit_ok_t *AMQP_CALL amqp_tx_commit(amqp_connection_state_t state,
                                               amqp_channel_t channel) {
   amqp_tx_commit_t req;
@@ -2849,7 +2849,7 @@ amqp_tx_commit_ok_t *AMQP_CALL amqp_tx_commit(amqp_connection_state_t state,
  * @param [in] channel the channel to do the RPC on
  * @returns amqp_tx_rollback_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_tx_rollback_ok_t *AMQP_CALL amqp_tx_rollback(amqp_connection_state_t state,
                                                   amqp_channel_t channel) {
   amqp_tx_rollback_t req;
@@ -2865,7 +2865,7 @@ amqp_tx_rollback_ok_t *AMQP_CALL amqp_tx_rollback(amqp_connection_state_t state,
  * @param [in] channel the channel to do the RPC on
  * @returns amqp_confirm_select_ok_t
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_confirm_select_ok_t *AMQP_CALL
     amqp_confirm_select(amqp_connection_state_t state, amqp_channel_t channel) {
   amqp_confirm_select_t req;

--- a/librabbitmq/codegen.py
+++ b/librabbitmq/codegen.py
@@ -263,7 +263,7 @@ def methodApiPrototype(m):
     docs += " * @returns %s_ok_t\n" % (fn)
     docs += " */\n"
 
-    return "%sAMQP_PUBLIC_FUNCTION\n%s_ok_t *\nAMQP_CALL %s(amqp_connection_state_t state, amqp_channel_t channel%s)" % (docs, fn, fn, ''.join(args))
+    return "%sAMQP_EXPORT\n%s_ok_t *\nAMQP_CALL %s(amqp_connection_state_t state, amqp_channel_t channel%s)" % (docs, fn, fn, ''.join(args))
 
 AmqpMethod.apiPrototype = methodApiPrototype
 
@@ -599,11 +599,11 @@ def genHrl(spec):
  * ***** END LICENSE BLOCK *****
  */
 
-/** @file amqp_framing.h */
-#ifndef AMQP_FRAMING_H
-#define AMQP_FRAMING_H
+/** @file rabbitmq-c/framing.h */
+#ifndef RABBITMQ_C_FRAMING_H
+#define RABBITMQ_C_FRAMING_H
 
-#include <amqp.h>
+#include <rabbitmq-c/amqp.h>
 
 AMQP_BEGIN_DECLS
 """
@@ -625,7 +625,7 @@ AMQP_BEGIN_DECLS
  * @returns string describing the constant. String is managed by
  *           the library and should not be free()'d by the program
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 char const *
 AMQP_CALL amqp_constant_name(int constantNumber);
 
@@ -638,7 +638,7 @@ AMQP_CALL amqp_constant_name(int constantNumber);
  * @param [in] constantNumber the error constant
  * @returns true if its a hard error, false otherwise
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_boolean_t
 AMQP_CALL amqp_constant_is_hard_error(int constantNumber);
 
@@ -649,7 +649,7 @@ AMQP_CALL amqp_constant_is_hard_error(int constantNumber);
  * @returns method name string. String is managed by the library
  *           and should not be freed()'d by the program
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 char const *
 AMQP_CALL amqp_method_name(amqp_method_number_t methodNumber);
 
@@ -662,7 +662,7 @@ AMQP_CALL amqp_method_name(amqp_method_number_t methodNumber);
  * @param [in] methodNumber the method number
  * @returns true if method has content, false otherwise
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 amqp_boolean_t
 AMQP_CALL amqp_method_has_content(amqp_method_number_t methodNumber);
 
@@ -675,7 +675,7 @@ AMQP_CALL amqp_method_has_content(amqp_method_number_t methodNumber);
  * @param [out] decoded pointer to the decoded method struct
  * @returns 0 on success, an error code otherwise
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int
 AMQP_CALL amqp_decode_method(amqp_method_number_t methodNumber,
 		   amqp_pool_t *pool,
@@ -691,7 +691,7 @@ AMQP_CALL amqp_decode_method(amqp_method_number_t methodNumber,
  * @param [out] decoded pointer to the decoded properties struct
  * @returns 0 on success, an error code otherwise
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int
 AMQP_CALL amqp_decode_properties(uint16_t class_id,
             amqp_pool_t *pool,
@@ -708,7 +708,7 @@ AMQP_CALL amqp_decode_properties(uint16_t class_id,
  *              to hold the encoded method, an error code will be returned.
  * @returns 0 on success, an error code otherwise.
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int
 AMQP_CALL amqp_encode_method(amqp_method_number_t methodNumber,
 		   void *decoded,
@@ -724,7 +724,7 @@ AMQP_CALL amqp_encode_method(amqp_method_number_t methodNumber,
  *              an error code will be returned
  * @returns 0 on success, an error code otherwise.
  */
-AMQP_PUBLIC_FUNCTION
+AMQP_EXPORT
 int
 AMQP_CALL amqp_encode_properties(uint16_t class_id,
 		       void *decoded,
@@ -773,7 +773,7 @@ AMQP_CALL amqp_encode_properties(uint16_t class_id,
     print """
 AMQP_END_DECLS
 
-#endif /* AMQP_FRAMING_H */"""
+#endif /* RABBITMQ_C_FRAMING_H */"""
 
 def generateErl(specPath):
     genErl(AmqpSpec(specPath))


### PR DESCRIPTION
Use cmake's GenerateExportHeader to define AMQP_EXPORT & AMQP_DEPRECATED
over the one in amqp.h. This is likely to be more correct over time.