### PR TITLE
ssl: Add support for TLSv1.3 and set minimum = TLSv1.2

### DIFF
--- a/include/rabbitmq-c/ssl_socket.h
+++ b/include/rabbitmq-c/ssl_socket.h
@@ -200,6 +200,7 @@ typedef enum {
   AMQP_TLSv1 = 1,
   AMQP_TLSv1_1 = 2,
   AMQP_TLSv1_2 = 3,
+  AMQP_TLSv1_3 = 4,
   AMQP_TLSvLATEST = 0xFFFF
 } amqp_tls_version_t;
 


### PR DESCRIPTION
Add support for TLSv1.3, and set the default supported versions to be
TLSv1.2 and TLSv1.3. TLSv1.0 and TLSv1.1 both have security flaws that make
them unsuitable as a default. If these versions are required, they can
be explicitly set by users to use these older versions.