### PR TITLE
Tweak LICENSE file so that github recognizes it

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,5 @@
+MIT License
+
 Portions created by Alan Antonuk are Copyright (c) 2012-2013
 Alan Antonuk. All Rights Reserved.
 


### PR DESCRIPTION
This does not change the license, rabbitmq-c is still licensed under the
the MIT license.

Signed-off-by: GitHub <noreply@github.com>