### PR TITLE
Remove unused CheckCCompilerFlag include

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,7 +44,6 @@ include(CheckSymbolExists)
 include(CheckLibraryExists)
 include(CMakePushCheckState)
 include(GNUInstallDirs)
-include(CheckCCompilerFlag)
 
 # Detect if we need to link against a socket library:
 cmake_push_check_state()


### PR DESCRIPTION
This appears to be unused.

Signed-off-by: GitHub <noreply@github.com>