### PR TITLE
phtread_ T different definitions exist on different platforms

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -30,7 +30,7 @@
 static int initialize_ssl_and_increment_connections(void);
 static int decrement_ssl_connections(void);
 
-static unsigned long ssl_threadid_callback(void);
+static pthread_t ssl_threadid_callback(void);
 static void ssl_locking_callback(int mode, int n, const char *file, int line);
 static pthread_mutex_t *amqp_openssl_lockarray = NULL;
 
@@ -583,12 +583,8 @@ void amqp_set_initialize_ssl_library(amqp_boolean_t do_initialize) {
   CHECK_SUCCESS(pthread_mutex_unlock(&openssl_init_mutex));
 }
 
-static unsigned long ssl_threadid_callback(void) {
-#ifdef _WIN32
-  return (unsigned long)pthread_self().p;
-#else
-  return (unsigned long)pthread_self();
-#endif
+static pthread_t ssl_threadid_callback(void) {
+  return pthread_self();
 }
 
 static void ssl_locking_callback(int mode, int n, AMQP_UNUSED const char *file,

--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -584,7 +584,11 @@ void amqp_set_initialize_ssl_library(amqp_boolean_t do_initialize) {
 }
 
 static unsigned long ssl_threadid_callback(void) {
+#ifdef _WIN32
+  return (unsigned long)pthread_self().p;
+#else
   return (unsigned long)pthread_self();
+#endif
 }
 
 static void ssl_locking_callback(int mode, int n, AMQP_UNUSED const char *file,


### PR DESCRIPTION
linux posix pthread_t Variable type：
typedef unsigned long int pthread_t;

window posix pthread_t Variable type：
/*
 * Generic handle type - intended to extend uniqueness beyond
 * that available with a simple pointer. It should scale for either
 * IA-32 or IA-64.
 */
typedef struct {
    void * p;                   /* Pointer to actual object */
    unsigned int x;             /* Extra information - reuse count etc */
} ptw32_handle_t;
typedef ptw32_handle_t pthread_t;

Will cause compilation to occur:
librabbitmq\amqp_openssl.c:605: error: aggregate value used where an integer was expected