### PR TITLE
restore compatibility with old Microsoft compilers

### DIFF
--- a/librabbitmq/amqp_private.h
+++ b/librabbitmq/amqp_private.h
@@ -45,7 +45,8 @@
 #define AMQP_UNUSED
 #endif
 
-#if (defined(__BORLANDC__) && (__BORLANDC__ <= 0x0564))
+#if (defined(_MSC_VER) && (_MSC_VER <= 1800)) || \
+    (defined(__BORLANDC__) && (__BORLANDC__ <= 0x0564))
 #define inline __inline
 #endif
 


### PR DESCRIPTION
master does not compile with vs2013 anymore.
Simple fix.
