### PR TITLE
fix invalid Cflags property name

### DIFF
--- a/librabbitmq.pc.in
+++ b/librabbitmq.pc.in
@@ -10,4 +10,4 @@ URL: https://github.com/alanxz/rabbitmq-c
 Requires.private: @requires_private@
 Libs: -L${libdir} -lrabbitmq
 Libs.private: @libs_private@
-CFlags: -I${includedir}
+Cflags: -I${includedir}


### PR DESCRIPTION
When `librabbitmq.pc` is parsed by SwiftPM, unable to retrieve the `CFlags` property value.
https://github.com/alanxz/rabbitmq-c/blob/6f831426e00ec8c42d2cc45ec03b652d491b320f/librabbitmq.pc.in#L13
This is caused by an invalid property name, according to man, must be `Cflags`