### PR TITLE
Use OpenSSL v1.1.0 API

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -9,6 +9,9 @@
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 
+// Use OpenSSL v1.1.0 API.
+#define OPENSSL_API_COMPAT 10100
+
 #include "amqp_openssl_bio.h"
 #include "amqp_private.h"
 #include "amqp_socket.h"

--- a/librabbitmq/amqp_openssl_bio.h
+++ b/librabbitmq/amqp_openssl_bio.h
@@ -4,6 +4,9 @@
 #ifndef AMQP_OPENSSL_BIO
 #define AMQP_OPENSSL_BIO
 
+// Use OpenSSL v1.1.0 API.
+#define OPENSSL_API_COMPAT 10100
+
 #include <openssl/bio.h>
 
 int amqp_openssl_bio_init(void);


### PR DESCRIPTION
This should stop warnings about deprecated APIs. RabbitMQ-c will adopt
OpenSSL 3.x APIs in a future version.

Fixed: #729

Signed-off-by: GitHub <noreply@github.com>