### PR TITLE
add option to install or not the static library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,6 +129,7 @@ include(CMakeDependentOption)
 
 option(BUILD_SHARED_LIBS "Build rabbitmq-c as a shared library" ON)
 option(BUILD_STATIC_LIBS "Build rabbitmq-c as a static library" ON)
+option(INSTALL_STATIC_LIBS "Install rabbitmq-c static library" ON)
 
 option(BUILD_EXAMPLES "Build Examples" OFF)
 option(BUILD_TOOLS "Build Tools (requires POPT Library)" OFF)
@@ -244,7 +245,7 @@ configure_package_config_file(
 if(BUILD_SHARED_LIBS)
     list(APPEND INSTALL_TARGETS rabbitmq)
 endif()
-if(BUILD_STATIC_LIBS)
+if(BUILD_STATIC_LIBS AND INSTALL_STATIC_LIBS)
     list(APPEND INSTALL_TARGETS rabbitmq-static)
 endif()
 

--- a/librabbitmq/CMakeLists.txt
+++ b/librabbitmq/CMakeLists.txt
@@ -142,10 +142,12 @@ if(BUILD_STATIC_LIBS)
     set_target_properties(rabbitmq-static PROPERTIES COMPILE_OPTIONS "/Z7")
   endif()
 
-  install(TARGETS rabbitmq-static EXPORT "${targets_export_name}"
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  if(INSTALL_STATIC_LIBS)
+    install(TARGETS rabbitmq-static EXPORT "${targets_export_name}"
+      ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
             COMPONENT rabbitmq-c-development
-  )
+    )
+  endif()
 
   add_library(rabbitmq::rabbitmq-static ALIAS rabbitmq-static)
 endif()


### PR DESCRIPTION
New version of #665 

This fixes an issue for downstream distribution, where static libraries are discouraged

For now (v0.10.0) we have to use **BUILD_TESTS + BUILD_STATIC_LIBS** to be able to run the test suite
and to exclude `librabbitmq.a `from the package

BUT installed cmake files contain references to the static library, so are (probably) unusable

This trivial fix allow to build but not install the static library, thus cmake files are clean.
