### PR TITLE
restore soname

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,8 +18,12 @@ set(RMQ_SOVERSION_REVISION  3)
 set(RMQ_SOVERSION_AGE       5)
 
 include(VersionFunctions)
-get_library_version(RMQ_VERSION)
-compute_soversion(${RMQ_SOVERSION_CURRENT} ${RMQ_SOVERSION_REVISION} ${RMQ_SOVERSION_AGE} RMQ_SOVERSION)
+get_library_version(VERSION)
+compute_soversion(${RMQ_SOVERSION_CURRENT} ${RMQ_SOVERSION_REVISION} ${RMQ_SOVERSION_AGE} RMQ_SOVERSION RMQ_VERSION)
+
+  message(STATUS "VERSION: " ${VERSION})
+  message(STATUS "RMQ_VERSION: " ${RMQ_VERSION})
+  message(STATUS "RMQ_SOVERSION: " ${RMQ_SOVERSION})
 
 project(rabbitmq-c 
   VERSION ${RMQ_VERSION}
@@ -233,7 +237,7 @@ set(version_config "${CMAKE_CURRENT_BINARY_DIR}/rabbitmq-c-config-version.cmake"
 
 write_basic_package_version_file(
     "${version_config}"
-    VERSION ${RMQ_VERSION}
+    VERSION ${VERSION}
     COMPATIBILITY AnyNewerVersion)
 
 configure_package_config_file(

--- a/cmake/VersionFunctions.cmake
+++ b/cmake/VersionFunctions.cmake
@@ -11,10 +11,11 @@ function(get_library_version VERSION_ARG)
     set(${VERSION_ARG} ${_API_VERSION_MAJOR}.${_API_VERSION_MINOR}.${_API_VERSION_PATCH} PARENT_SCOPE)
 endfunction()
 
-function(compute_soversion CURRENT REVISION AGE SOVERSION)
+function(compute_soversion CURRENT REVISION AGE SOVERSION FULLVERSION)
     math(EXPR MAJOR "${CURRENT} - ${AGE}")
     math(EXPR MINOR "${AGE}")
     math(EXPR PATCH "${REVISION}")
 
     set(${SOVERSION} ${MAJOR} PARENT_SCOPE)
+    set(${FULLVERSION} ${MAJOR}.${MINOR}.${PATCH} PARENT_SCOPE)
 endfunction()


### PR DESCRIPTION
Version 0.11.0 have soname = 4.5.0
Version 0.12.0 have soname = 0.12.0 which is not expected

With this patch, soname is restored (4.5.2)


P.S. this also use already merged from #667 