### PR TITLE
fix empty version for pkgconfig

### DIFF
--- a/librabbitmq.pc.in
+++ b/librabbitmq.pc.in
@@ -5,7 +5,7 @@ includedir=@includedir@
 
 Name: rabbitmq-c
 Description: An AMQP 0-9-1 client library
-Version: @VERSION@
+Version: @RMQ_VERSION@
 URL: https://github.com/alanxz/rabbitmq-c
 Requires.private: @requires_private@
 Libs: -L${libdir} -lrabbitmq


### PR DESCRIPTION
So we have in `librabbitmq.pc`:

`Version: 0.13.0`

VERSION is not defined, while RMQ_VERSION is