### PR TITLE
fix: correct amqp_ssl_socket_set_key_buffer value

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -451,6 +451,7 @@ int amqp_ssl_socket_set_key_buffer(amqp_socket_t *base, const char *cert,
   if (1 != status) {
     goto error;
   }
+  status = AMQP_STATUS_OK;
 exit:
   BIO_vfree(buf);
   RSA_free(rsa);


### PR DESCRIPTION
Make amqp_ssl_socket_set_key_buffer return AMQP_STATUS_OK on success. It currently returns the status of the underlying OpenSSL call, which isn't correct.

Fixes: alanxz/rabbitmq-c#723

Signed-off-by: GitHub <noreply@github.com>