### PR TITLE
Improve fuzz_table fuzzing test case.

### DIFF
--- a/fuzz/fuzz_table.c
+++ b/fuzz/fuzz_table.c
@@ -13,7 +13,7 @@
 
 extern int LLVMFuzzerTestOneInput(const char *data, size_t size) {
 
-  int result;
+  int unused_result;
   amqp_pool_t pool;
 
   init_amqp_pool(&pool, 4096);
@@ -24,8 +24,9 @@ extern int LLVMFuzzerTestOneInput(const char *data, size_t size) {
     decoding_bytes.len = size;
     decoding_bytes.bytes = (uint8_t *)data;
 
-    result =
+    unused_result =
         amqp_decode_table(decoding_bytes, &pool, &decoded, &decoding_offset);
   }
-  return result;
+  empty_amqp_pool(&pool);
+  return 0;
 }


### PR DESCRIPTION
1. The amqp_pool_t must be emptied after use using empty_amqp_pool
   (which should correct the obvious issue with a leak detected in:
   https://bugs.chromium.org/p/oss-fuzz/issues/detail?id=56161).
2. The return value of amqp_decode_table will be non-zero when it cannot
   decode the table, this is working as expected. So this value should
   not be returned out of a single loop.

Signed-off-by: GitHub <noreply@github.com>