### PR TITLE
Improve fuzz_url fuzzing test case

### DIFF
--- a/fuzz/fuzz_url.c
+++ b/fuzz/fuzz_url.c
@@ -4,14 +4,21 @@
 #include <inttypes.h>
 #include <stddef.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include <rabbitmq-c/amqp.h>
 
 extern int LLVMFuzzerTestOneInput(const char *data, size_t size) {
+  // amqp_parse_url expects null-terminated string that it can modify,
+  // LLVMFuzzer expects that data will not be modified and won't necessarily
+  // null terminate the string, so do that here.
+  char* in = malloc(size + 1);
+  memcpy(in, data, size);
+  in[size] = '\0';
 
   struct amqp_connection_info ci;
-  int res;
-  res = amqp_parse_url((char *)data, &ci);
-  return res;
+  amqp_parse_url(in, &ci);
+  free(in);
+  return 0;
 }


### PR DESCRIPTION
1. Always null-terminate the string provided, this is a requirement of
   the API itself.
2. Provide a string that amqp_parse_url can modify. This API modifies
   its input (fixes: https://crbug.com/oss-fuzz/56162).
3. Always return 0 from the fuzzing function. It is expected that
   amqp_parse_url will return non-0 when it fails to parse the input.

Signed-off-by: GitHub <noreply@github.com>