### PR TITLE
Update CodeQL action to v2

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -28,7 +28,7 @@ jobs:
       uses: actions/checkout@v2
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: ${{ matrix.language }}
 
@@ -47,4 +47,4 @@ jobs:
        cmake --build build
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2


### PR DESCRIPTION
v1 was deprecated as of Jan 18, 2023, see:
https://github.blog/changelog/2023-01-18-code-scanning-codeql-action-v1-is-now-deprecated/

Signed-off-by: GitHub <noreply@github.com>