### PR TITLE
Correct library versions on Mach-O platforms

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright 2007 - 2021, Alan Antonuk and the rabbitmq-c contributors.
 # SPDX-License-Identifier: mit
 
-cmake_minimum_required(VERSION 3.12...3.18)
+cmake_minimum_required(VERSION 3.17...3.26)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 

--- a/librabbitmq/CMakeLists.txt
+++ b/librabbitmq/CMakeLists.txt
@@ -90,6 +90,13 @@ if(BUILD_SHARED_LIBS)
     SOVERSION ${RMQ_SOVERSION}
   )
 
+  if (APPLE)
+    set_target_properties(rabbitmq PROPERTIES
+      MACHO_CURRENT_VERSION ${RMQ_SOVERSION}.${RMQ_SOVERSION_AGE}.${RMQ_SOVERSION_REVISION}
+      MACHO_COMPATIBILITY_VERSION ${RMQ_SOVERSION}
+    )
+  endif()
+
   if (WIN32)
     set_target_properties(rabbitmq PROPERTIES OUTPUT_NAME rabbitmq.${RMQ_SOVERSION})
   endif()
@@ -129,7 +136,15 @@ if(BUILD_STATIC_LIBS)
 
   set_target_properties(rabbitmq-static PROPERTIES
     VERSION ${RMQ_VERSION}
-    SOVERSION ${RMQ_SOVERSION})
+    SOVERSION ${RMQ_SOVERSION}
+  )
+
+  if (APPLE)
+    set_target_properties(rabbitmq PROPERTIES
+      MACHO_CURRENT_VERSION ${RMQ_SOVERSION}.${RMQ_SOVERSION_AGE}.${RMQ_SOVERSION_REVISION}
+      MACHO_COMPATIBILITY_VERSION ${RMQ_SOVERSION}
+    )
+  endif()
 
   if (WIN32)
     set_target_properties(rabbitmq-static PROPERTIES OUTPUT_NAME librabbitmq.${RMQ_SOVERSION})


### PR DESCRIPTION
Set the compatibility and current version strings on Mach-O (Apple) platforms. The compatibility version remains the same as the SOVERSION, the current version is SOVERSION.AGE.REVISION, which matches the previous libtool semantics for this.

Fixes #758