### PR TITLE
cmake: bump minimum required version to 3.22

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 # Copyright 2007 - 2021, Alan Antonuk and the rabbitmq-c contributors.
 # SPDX-License-Identifier: mit
 
-cmake_minimum_required(VERSION 3.17...3.26)
+cmake_minimum_required(VERSION 3.22...3.26)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 


### PR DESCRIPTION
This is the version that is installed on Ubuntu 22.04-LTS, and what is possible to regularly test with the current infrastructure. 3.19+ is needed to allow for use of CMakePresets.json.