### PR TITLE
Fuzz_localhost

### DIFF
--- a/fuzz/fuzz_server.c
+++ b/fuzz/fuzz_server.c
@@ -124,7 +124,7 @@ void client(Fuzzer *fuzzer) {
   amqp_socket_t *socket = NULL;
   amqp_connection_state_t conn;
 
-  hostname = "localhost";
+  hostname = "127.0.0.1";
 
   conn = amqp_new_connection();
 


### PR DESCRIPTION
We're observing ENETUNREACH, the thought is that something about name
lookup is returning something that we cannot connect to, which makes
connect fail eith ENETUNREACH.

Signed-off-by: GitHub <noreply@github.com>