### PR TITLE
Make rabbitmq-c-config.cmake find OpenSSL dependency when used

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,7 +113,8 @@ endif()
 option(ENABLE_SSL_SUPPORT "Enable SSL support" ON)
 
 if (ENABLE_SSL_SUPPORT)
-  find_package(OpenSSL 1.1.1 REQUIRED)
+  set(RMQ_OPENSSL_MIN_VERSION 1.1.1)
+  find_package(OpenSSL "${RMQ_OPENSSL_MIN_VERSION}" REQUIRED)
 
   cmake_push_check_state()
   set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,7 +220,7 @@ set(version_config "${CMAKE_CURRENT_BINARY_DIR}/rabbitmq-c-config-version.cmake"
 write_basic_package_version_file(
     "${version_config}"
     VERSION ${RMQ_VERSION}
-    COMPATIBILITY AnyNewerVersion)
+    COMPATIBILITY SameMajorVersion)
 
 configure_package_config_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/rabbitmq-c-config.cmake.in"

--- a/cmake/rabbitmq-c-config.cmake.in
+++ b/cmake/rabbitmq-c-config.cmake.in
@@ -1,4 +1,12 @@
 @PACKAGE_INIT@
 
+set(RMQ_USES_OPENSSL @ENABLE_SSL_SUPPORT@)
+
+include(CMakeFindDependencyMacro)
+
+if (RMQ_USES_OPENSSL)
+  find_dependency(OpenSSL @RMQ_OPENSSL_MIN_VERSION@ REQUIRED)
+endif ()
+
 include(${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake)
 check_required_components(rabbitmq-c)


### PR DESCRIPTION
This makes the rabbitmq-c-config.cmake package config correctly find
the OpenSSL library dependency when required.

Fixes: #725