### PR TITLE
Add option to read username/password from file

### DIFF
--- a/tools/common.c
+++ b/tools/common.c
@@ -18,6 +18,11 @@
 #include "compat.h"
 #endif
 
+/* For when reading auth data from a file */
+#define MAXAUTHTOKENLEN 128
+#define USERNAMEPREFIX  "username:"
+#define PASSWORDPREFIX  "password:"
+
 void die(const char *fmt, ...) {
   va_list ap;
   va_start(ap, fmt);
@@ -125,6 +130,7 @@ static char *amqp_vhost;
 static char *amqp_username;
 static char *amqp_password;
 static int amqp_heartbeat = 0;
+static char *amqp_authfile;
 #ifdef WITH_SSL
 static int amqp_ssl = 0;
 static char *amqp_cacert = "/etc/ssl/certs/cacert.pem";
@@ -147,6 +153,8 @@ struct poptOption connect_options[] = {
      "the password to login with", "password"},
     {"heartbeat", 0, POPT_ARG_INT, &amqp_heartbeat, 0,
      "heartbeat interval, set to 0 to disable", "heartbeat"},
+    {"authfile", 0, POPT_ARG_STRING, &amqp_authfile, 0,
+     "path to file containing username/password for authentication", "file"},
 #ifdef WITH_SSL
     {"ssl", 0, POPT_ARG_NONE, &amqp_ssl, 0, "connect over SSL/TLS", NULL},
     {"cacert", 0, POPT_ARG_STRING, &amqp_cacert, 0,
@@ -157,6 +165,51 @@ struct poptOption connect_options[] = {
      "path to the client certificate file", "cert.pem"},
 #endif /* WITH_SSL */
     {NULL, '\0', 0, NULL, 0, NULL, NULL}};
+
+void read_authfile(const char *path)
+{
+  size_t n;
+  FILE *fp;
+  char token[MAXAUTHTOKENLEN];
+
+  if ((amqp_username = malloc(MAXAUTHTOKENLEN)) == NULL ||
+      (amqp_password = malloc(MAXAUTHTOKENLEN)) == NULL) {
+    die("Out of memory");
+  } else if ((fp = fopen(path, "r")) == NULL) {
+    die("Could not read auth data file", path);
+  }
+
+  if (fgets(token, MAXAUTHTOKENLEN, fp) == NULL ||
+      strncmp(token, USERNAMEPREFIX, strlen(USERNAMEPREFIX))) {
+    die("Malformed auth file (missing username)");
+  }
+  strncpy(amqp_username, &token[strlen(USERNAMEPREFIX)], MAXAUTHTOKENLEN);
+  /* Missing newline means token was cut off */
+  n = strlen(amqp_username);
+  if (amqp_username[n-1] != '\n') {
+    die("Username too long");
+  } else {
+    amqp_username[n-1] = '\0';
+  }
+
+  if (fgets(token, MAXAUTHTOKENLEN, fp) == NULL ||
+      strncmp(token, PASSWORDPREFIX, strlen(PASSWORDPREFIX))) {
+    die("Malformed auth file (missing password)");
+  }
+  strncpy(amqp_password, &token[strlen(PASSWORDPREFIX)], MAXAUTHTOKENLEN);
+  /* Missing newline means token was cut off */
+  n = strlen(amqp_password);
+  if (amqp_password[n-1] != '\n') {
+    die("Password too long");
+  } else {
+    amqp_password[n-1] = '\0';
+  }
+
+  (void) fgetc(fp);
+  if (!feof(fp)) {
+    die("Malformed auth file (trailing data)");
+  }
+}
 
 static void init_connection_info(struct amqp_connection_info *ci) {
   ci->user = NULL;
@@ -237,6 +290,8 @@ static void init_connection_info(struct amqp_connection_info *ci) {
   if (amqp_username) {
     if (amqp_url) {
       die("--username and --url options cannot be used at the same time");
+    } else if (amqp_authfile) {
+      die("--username and --authfile options cannot be used at the same time");
     }
 
     ci->user = amqp_username;
@@ -245,8 +300,20 @@ static void init_connection_info(struct amqp_connection_info *ci) {
   if (amqp_password) {
     if (amqp_url) {
       die("--password and --url options cannot be used at the same time");
+    } else if (amqp_authfile) {
+      die("--password and --authfile options cannot be used at the same time");
     }
 
+    ci->password = amqp_password;
+  }
+
+  if (amqp_authfile) {
+    if (amqp_url) {
+      die("--authfile and --url options cannot be used at the same time");
+    }
+
+    read_authfile(amqp_authfile);
+    ci->user = amqp_username;
     ci->password = amqp_password;
   }
 

--- a/tools/common.c
+++ b/tools/common.c
@@ -168,7 +168,7 @@ struct poptOption connect_options[] = {
 
 void read_authfile(const char *path) {
   size_t n;
-  FILE *fp;
+  FILE *fp = NULL;
   char token[MAXAUTHTOKENLEN];
 
   if ((amqp_username = malloc(MAXAUTHTOKENLEN)) == NULL ||

--- a/tools/common.c
+++ b/tools/common.c
@@ -175,7 +175,7 @@ void read_authfile(const char *path) {
       (amqp_password = malloc(MAXAUTHTOKENLEN)) == NULL) {
     die("Out of memory");
   } else if ((fp = fopen(path, "r")) == NULL) {
-    die("Could not read auth data file", path);
+    die("Could not read auth data file %s", path);
   }
 
   if (fgets(token, MAXAUTHTOKENLEN, fp) == NULL ||

--- a/tools/common.c
+++ b/tools/common.c
@@ -20,8 +20,8 @@
 
 /* For when reading auth data from a file */
 #define MAXAUTHTOKENLEN 128
-#define USERNAMEPREFIX  "username:"
-#define PASSWORDPREFIX  "password:"
+#define USERNAMEPREFIX "username:"
+#define PASSWORDPREFIX "password:"
 
 void die(const char *fmt, ...) {
   va_list ap;
@@ -166,8 +166,7 @@ struct poptOption connect_options[] = {
 #endif /* WITH_SSL */
     {NULL, '\0', 0, NULL, 0, NULL, NULL}};
 
-void read_authfile(const char *path)
-{
+void read_authfile(const char *path) {
   size_t n;
   FILE *fp;
   char token[MAXAUTHTOKENLEN];
@@ -186,10 +185,10 @@ void read_authfile(const char *path)
   strncpy(amqp_username, &token[strlen(USERNAMEPREFIX)], MAXAUTHTOKENLEN);
   /* Missing newline means token was cut off */
   n = strlen(amqp_username);
-  if (amqp_username[n-1] != '\n') {
+  if (amqp_username[n - 1] != '\n') {
     die("Username too long");
   } else {
-    amqp_username[n-1] = '\0';
+    amqp_username[n - 1] = '\0';
   }
 
   if (fgets(token, MAXAUTHTOKENLEN, fp) == NULL ||
@@ -199,13 +198,13 @@ void read_authfile(const char *path)
   strncpy(amqp_password, &token[strlen(PASSWORDPREFIX)], MAXAUTHTOKENLEN);
   /* Missing newline means token was cut off */
   n = strlen(amqp_password);
-  if (amqp_password[n-1] != '\n') {
+  if (amqp_password[n - 1] != '\n') {
     die("Password too long");
   } else {
-    amqp_password[n-1] = '\0';
+    amqp_password[n - 1] = '\0';
   }
 
-  (void) fgetc(fp);
+  (void)fgetc(fp);
   if (!feof(fp)) {
     die("Malformed auth file (trailing data)");
   }


### PR DESCRIPTION
This fixes #575 by adding an option `--authfile`. The argument is expected to be a filename with the following exact syntax:

```
username:foo
password:password123
```

In spirit with `--url`, `--username` and `--password` checks, it is a conflict when `--authfile` is used when any of these other options are used.