### PR TITLE
Fix ssl x509 check host failed problem using host name instead of ip

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -233,7 +233,7 @@ start_connect:
       goto error_out3;
     }
 
-    if (1 != X509_check_host(cert, host, 0,
+    if (1 != X509_check_host(cert, host, strlen(host),
                              X509_CHECK_FLAG_NO_PARTIAL_WILDCARDS, NULL)) {
       self->internal_error = 0;
       status = AMQP_STATUS_SSL_HOSTNAME_VERIFY_FAILED;


### PR DESCRIPTION
In current version of project when you try to connect rabbitmq server using host name like rabbit.server, returns AMQP_STATUS_SSL_HOSTNAME_VERIFY_FAILED error. Because host name length parameter of X509_check_host function is hard coded 0. It should be length of the given host name.