### PR TITLE
Add API to enable loading default CA certificates for a socket

### DIFF
--- a/include/rabbitmq-c/ssl_socket.h
+++ b/include/rabbitmq-c/ssl_socket.h
@@ -50,6 +50,19 @@ AMQP_EXPORT
 void *AMQP_CALL amqp_ssl_socket_get_context(amqp_socket_t *self);
 
 /**
+ * Enable loading of the CA certificates from the default location.
+ *
+ * \param [in,out] self An SSL/TLS socket object.
+ *
+ * \return \ref AMQP_STATUS_OK on success an \ref amqp_status_enum value on
+ *  failure.
+ *
+ * \since v0.12.0
+ */
+AMQP_EXPORT
+int AMQP_CALL amqp_ssl_socket_enable_default_verify_paths(amqp_socket_t *self);
+
+/**
  * Set the CA certificate.
  *
  * \param [in,out] self An SSL/TLS socket object.

--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -359,6 +359,20 @@ void *amqp_ssl_socket_get_context(amqp_socket_t *base) {
   return ((struct amqp_ssl_socket_t *)base)->ctx;
 }
 
+int amqp_ssl_socket_enable_default_verify_paths(amqp_socket_t *base) {
+  int status;
+  struct amqp_ssl_socket_t *self;
+  if (base->klass != &amqp_ssl_socket_class) {
+    amqp_abort("<%p> is not of type amqp_ssl_socket_t", base);
+  }
+  self = (struct amqp_ssl_socket_t *)base;
+  status = SSL_CTX_set_default_verify_paths(self->ctx);
+  if (1 != status) {
+    return AMQP_STATUS_SSL_ERROR;
+  }
+  return AMQP_STATUS_OK;
+}
+
 int amqp_ssl_socket_set_cacert(amqp_socket_t *base, const char *cacert) {
   int status;
   struct amqp_ssl_socket_t *self;


### PR DESCRIPTION

Fixes: #648 
Obsoletes #720 