### PR TITLE
Added an explicit include for rsa.h, needed for openssl 1.1.1+ support

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -25,8 +25,8 @@
 #include <openssl/conf.h>
 #include <openssl/engine.h>
 #include <openssl/err.h>
-#include <openssl/ssl.h>
 #include <openssl/rsa.h>
+#include <openssl/ssl.h>
 #include <openssl/x509v3.h>
 #include <stdlib.h>
 #include <string.h>

--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -26,6 +26,7 @@
 #include <openssl/engine.h>
 #include <openssl/err.h>
 #include <openssl/ssl.h>
+#include <openssl/rsa.h>
 #include <openssl/x509v3.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
Cross-compiling on my Intel mac for an arm64 mac failed at the build phase due to a missing include for `rsa.h`. I tested on `v0.13.0` but was unable to test on master due to a cmake error (I can make a separate ticket for that if needed).

I depend on OpenSSL 1.1.1w (for better cross-compilation support) and am guessing older releases of OpenSSL have a different include graph that must indirectly include `rsa.h`.