### PR TITLE
Conditionally enable SSL ENGINE APIs when available

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,7 @@ endif()
 
 include(CheckSymbolExists)
 include(CheckLibraryExists)
+include(CMakeDependentOption)
 include(CMakePushCheckState)
 include(GNUInstallDirs)
 
@@ -120,13 +121,18 @@ if (ENABLE_SSL_SUPPORT)
   set(THREADS_PREFER_PTHREAD_FLAG ON)
   find_package(Threads REQUIRED)
   cmake_pop_check_state()
+
+  cmake_push_check_state()
+  set(CMAKE_REQUIRED_LIBRARIES OpenSSL::SSL)
+  check_symbol_exists(ENGINE_new openssl/engine.h HAS_OPENSSL_ENGINE)
+  cmake_pop_check_state()
+
+  cmake_dependent_option(ENABLE_SSL_ENGINE_API "Enable support for deprecated OpenSSL ENGINE feature" ON "HAS_OPENSSL_ENGINE" OFF)
 endif()
 
 if(CMAKE_PROJECT_NAME STREQUAL PROJECT_NAME)
   include(CTest)
 endif()
-
-include(CMakeDependentOption)
 
 option(BUILD_SHARED_LIBS "Build rabbitmq-c as a shared library" ON)
 option(BUILD_STATIC_LIBS "Build rabbitmq-c as a static library" ON)

--- a/cmake/config.h.in
+++ b/cmake/config.h.in
@@ -7,4 +7,6 @@
 
 #define AMQ_PLATFORM "@CMAKE_SYSTEM_NAME@"
 
+#cmakedefine ENABLE_SSL_ENGINE_API
+
 #endif /* CONFIG_H */

--- a/include/rabbitmq-c/amqp.h
+++ b/include/rabbitmq-c/amqp.h
@@ -670,7 +670,8 @@ typedef enum amqp_status_enum_ {
                                                          certificate failed. */
   AMQP_STATUS_SSL_CONNECTION_FAILED = -0x0203, /**< SSL handshake failed. */
   AMQP_STATUS_SSL_SET_ENGINE_FAILED = -0x0204, /**< SSL setting engine failed */
-  _AMQP_STATUS_SSL_NEXT_VALUE = -0x0205        /**< Internal value */
+  AMQP_STATUS_SSL_UNIMPLEMENTED = -0x0205, /**< SSL API is not implemented. */
+  _AMQP_STATUS_SSL_NEXT_VALUE = -0x0206        /**< Internal value */
 } amqp_status_enum;
 
 /**

--- a/include/rabbitmq-c/ssl_socket.h
+++ b/include/rabbitmq-c/ssl_socket.h
@@ -115,7 +115,8 @@ int AMQP_CALL amqp_ssl_socket_set_key(amqp_socket_t *self, const char *cert,
  * \param [in] the key ID.
  *
  * \return \ref AMQP_STATUS_OK on success an \ref amqp_status_enum value on
- *  failure.
+ *  failure. May return \ref AMQP_STATUS_SSL_UNIMPLEMENTED if OpenSSL does 
+ *  not support the ENGINE API.
  *
  * \since v0.11.0
  */
@@ -278,7 +279,8 @@ int AMQP_CALL amqp_initialize_ssl_library(void);
  * has been called.
  *
  * \param [in] engine the engine ID
- * \return AMQP_STATUS_OK on success.
+ * \return AMQP_STATUS_OK on success. May return \ref AMQP_STATUS_SSL_UNIMPLEMENTED
+ *   if OpenSSL does not support the ENGINE API.
  *
  * \since v0.11.0
  */

--- a/librabbitmq/amqp_api.c
+++ b/librabbitmq/amqp_api.c
@@ -85,7 +85,9 @@ static const char *ssl_error_strings[] = {
     /* AMQP_STATUS_SSL_CONNECTION_FAILED      -0x0203 */
     "SSL handshake failed",
     /* AMQP_STATUS_SSL_SET_ENGINE_FAILED      -0x0204 */
-    "SSL setting engine failed"};
+    "SSL setting engine failed",
+    /* AMQP_STATUS_SSL_UNIMPLEMENTED          -0x0204 */
+    "SSL API is not implemented"};
 
 static const char *unknown_error_string = "(unknown error)";
 


### PR DESCRIPTION
Conditionally enable ssl_socket methods that use the deprecated OpenSSL
ENGINE APIs. The APIs are enabled when the OpenSSL being compiled
against has the ENGINE APIs enabled. In addition these APIs can be
disabled by passing -DENABLE_SSL_ENGINE_API=OFF to CMake at build-time.

Fixed: alanxz/rabbitmq-c#795
Fixed: alanxz/rabbitmq-c#713

Signed-off-by: GitHub <noreply@github.com>