### PR TITLE
Fix no-such target error on MacOS when built statically

### DIFF
--- a/librabbitmq/CMakeLists.txt
+++ b/librabbitmq/CMakeLists.txt
@@ -140,7 +140,7 @@ if(BUILD_STATIC_LIBS)
   )
 
   if (APPLE)
-    set_target_properties(rabbitmq PROPERTIES
+    set_target_properties(rabbitmq-static PROPERTIES
       MACHO_CURRENT_VERSION ${RMQ_SOVERSION}.${RMQ_SOVERSION_AGE}.${RMQ_SOVERSION_REVISION}
       MACHO_COMPATIBILITY_VERSION ${RMQ_SOVERSION}
     )


### PR DESCRIPTION
Corrects bug where cmake fails on MacOS when building static-only
library with an error that looks like:

CMake Error at librabbitmq/CMakeLists.txt:143 (set_target_properties):
  set_target_properties Can not find target to add properties to: rabbitmq

Fixed: alanxz/rabbitmq-c#796

Signed-off-by: GitHub <noreply@github.com>