### PR TITLE
Don't set /Z7 flag when compiling with MSVC

### DIFF
--- a/librabbitmq/CMakeLists.txt
+++ b/librabbitmq/CMakeLists.txt
@@ -152,11 +152,6 @@ if(BUILD_STATIC_LIBS)
     set_target_properties(rabbitmq-static PROPERTIES OUTPUT_NAME rabbitmq)
   endif()
 
-  if(MSVC)
-    # Embed debugging info in the library itself instead of generating a .pdb file.
-    set_target_properties(rabbitmq-static PROPERTIES COMPILE_OPTIONS "/Z7")
-  endif()
-
   if(INSTALL_STATIC_LIBS)
     install(TARGETS rabbitmq-static EXPORT "${targets_export_name}"
       ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}


### PR DESCRIPTION
The decision to use this flag should be up to the user of this library.
If users need this functionality they can include this as a part of
CMAKE_C_FLAGS.

Signed-off-by: GitHub <noreply@github.com>