### PR TITLE
BoringSSL support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,8 +114,14 @@ endif()
 option(ENABLE_SSL_SUPPORT "Enable SSL support" ON)
 
 if (ENABLE_SSL_SUPPORT)
+  # Manually check OpenSSL version because BoringSSL doesn't support version checking via find_package
   set(RMQ_OPENSSL_MIN_VERSION 1.1.1)
   find_package(OpenSSL REQUIRED)
+  if(OPENSSL_VERSION) # Will be empty for BoringSSL
+    if(OPENSSL_VERSION VERSION_LESS RMQ_OPENSSL_MIN_VERSION)
+      MESSAGE(FATAL_ERROR "Found OpenSSL version ${OPENSSL_VERSION} but ${RMQ_OPENSSL_MIN_VERSION} or later is required")
+    endif()
+  endif()
 
   cmake_push_check_state()
   set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -115,7 +115,7 @@ option(ENABLE_SSL_SUPPORT "Enable SSL support" ON)
 
 if (ENABLE_SSL_SUPPORT)
   set(RMQ_OPENSSL_MIN_VERSION 1.1.1)
-  find_package(OpenSSL "${RMQ_OPENSSL_MIN_VERSION}" REQUIRED)
+  find_package(OpenSSL REQUIRED)
 
   cmake_push_check_state()
   set(THREADS_PREFER_PTHREAD_FLAG ON)

--- a/cmake/rabbitmq-c-config.cmake.in
+++ b/cmake/rabbitmq-c-config.cmake.in
@@ -5,7 +5,12 @@ set(RMQ_USES_OPENSSL @ENABLE_SSL_SUPPORT@)
 include(CMakeFindDependencyMacro)
 
 if (RMQ_USES_OPENSSL)
-  find_dependency(OpenSSL @RMQ_OPENSSL_MIN_VERSION@ REQUIRED)
+  find_dependency(OpenSSL REQUIRED)
+  if(OPENSSL_VERSION)
+    if(OPENSSL_VERSION VERSION_LESS RMQ_OPENSSL_MIN_VERSION)
+      MESSAGE(FATAL_ERROR "Found OpenSSL version @OPENSSL_VERSION@ but @RMQ_OPENSSL_MIN_VERSION@ or later is required")
+    endif()
+  endif()
 endif ()
 
 include(${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake)

--- a/librabbitmq/amqp_openssl_bio.c
+++ b/librabbitmq/amqp_openssl_bio.c
@@ -108,7 +108,7 @@ int amqp_openssl_bio_init(void) {
   if (!(amqp_bio_method = BIO_meth_new(BIO_TYPE_SOCKET, "amqp_bio_method"))) {
     return AMQP_STATUS_NO_MEMORY;
   }
-
+#ifdef OPENSSL_IS_BORINGSSL
   BIO_meth_set_create(amqp_bio_method, BIO_s_socket()->create);
   BIO_meth_set_destroy(amqp_bio_method, BIO_s_socket()->destroy);
   BIO_meth_set_ctrl(amqp_bio_method, BIO_s_socket()->ctrl);
@@ -116,6 +116,17 @@ int amqp_openssl_bio_init(void) {
   BIO_meth_set_write(amqp_bio_method, BIO_s_socket()->bwrite);
   BIO_meth_set_gets(amqp_bio_method, BIO_s_socket()->bgets);
   BIO_meth_set_puts(amqp_bio_method, BIO_s_socket()->bputs);
+#else
+  BIO_meth_set_create(amqp_bio_method, BIO_meth_get_create(BIO_s_socket()));
+  BIO_meth_set_destroy(amqp_bio_method, BIO_meth_get_destroy(BIO_s_socket()));
+  BIO_meth_set_ctrl(amqp_bio_method, BIO_meth_get_ctrl(BIO_s_socket()));
+  BIO_meth_set_callback_ctrl(amqp_bio_method,
+                             BIO_meth_get_callback_ctrl(BIO_s_socket()));
+  BIO_meth_set_read(amqp_bio_method, BIO_meth_get_read(BIO_s_socket()));
+  BIO_meth_set_write(amqp_bio_method, BIO_meth_get_write(BIO_s_socket()));
+  BIO_meth_set_gets(amqp_bio_method, BIO_meth_get_gets(BIO_s_socket()));
+  BIO_meth_set_puts(amqp_bio_method, BIO_meth_get_puts(BIO_s_socket()));
+#endif
 
   BIO_meth_set_write(amqp_bio_method, amqp_openssl_bio_write);
   BIO_meth_set_read(amqp_bio_method, amqp_openssl_bio_read);

--- a/librabbitmq/amqp_openssl_bio.c
+++ b/librabbitmq/amqp_openssl_bio.c
@@ -109,15 +109,13 @@ int amqp_openssl_bio_init(void) {
     return AMQP_STATUS_NO_MEMORY;
   }
 
-  BIO_meth_set_create(amqp_bio_method, BIO_meth_get_create(BIO_s_socket()));
-  BIO_meth_set_destroy(amqp_bio_method, BIO_meth_get_destroy(BIO_s_socket()));
-  BIO_meth_set_ctrl(amqp_bio_method, BIO_meth_get_ctrl(BIO_s_socket()));
-  BIO_meth_set_callback_ctrl(amqp_bio_method,
-                             BIO_meth_get_callback_ctrl(BIO_s_socket()));
-  BIO_meth_set_read(amqp_bio_method, BIO_meth_get_read(BIO_s_socket()));
-  BIO_meth_set_write(amqp_bio_method, BIO_meth_get_write(BIO_s_socket()));
-  BIO_meth_set_gets(amqp_bio_method, BIO_meth_get_gets(BIO_s_socket()));
-  BIO_meth_set_puts(amqp_bio_method, BIO_meth_get_puts(BIO_s_socket()));
+  BIO_meth_set_create(amqp_bio_method, BIO_s_socket()->create);
+  BIO_meth_set_destroy(amqp_bio_method, BIO_s_socket()->destroy);
+  BIO_meth_set_ctrl(amqp_bio_method, BIO_s_socket()->ctrl);
+  BIO_meth_set_read(amqp_bio_method, BIO_s_socket()->bread);
+  BIO_meth_set_write(amqp_bio_method, BIO_s_socket()->bwrite);
+  BIO_meth_set_gets(amqp_bio_method, BIO_s_socket()->bgets);
+  BIO_meth_set_puts(amqp_bio_method, BIO_s_socket()->bputs);
 
   BIO_meth_set_write(amqp_bio_method, amqp_openssl_bio_write);
   BIO_meth_set_read(amqp_bio_method, amqp_openssl_bio_read);


### PR DESCRIPTION
# BoringSSL support
This is a PR to compile/link RabbitMQ against _either_ BoringSSL or OpenSSL. 

## Why BoringSSL?
Consider an **Android** static library that depends on both `librabbitmq` and `libcurl`. 
```mermaid
graph TD;
   myLib.a--> librabbitmq.a;
   myLib.a-->libcurl.a;
   librabbitmq.a-->libssl.a+libcrypto.a;
   libcurl.a-->libssl.a+libcrypto.a;
```
OpenSSL isn't the best option because it doesn't naturally support the certificates on an Android device. Forcing it to work involves either including certificates with `mylib.a` or modifying the user's file system.

`libcurl` expects to link against BoringSSL for Android, but RabbitMQ only compiles/links against OpenSSL. BoringSSL is a fork from OpenSSL so`mylib.a` cannot compile/link against both without getting collisions.

I have verified that BoringSSL works out-of-the-box on Android without any hacking for `libcurl`, and that this PR allows `librabbitmq` to work with BoringSSL in my limited tests. Backward compatibility with OpenSSL has been maintained.