### PR TITLE
Use image-default OpenSSL on Win32 Github Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,8 +67,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - name: Install Prerequisites
-      run: choco install openssl
     - name: Configure Build & Test
       shell: bash
       run: |


### PR DESCRIPTION
For some reason the latest version provided by Chocolatey, the headers were being picked up as the choco installed version, and the library was the runner-image installed version, which was leading to symbol not found type errors.

Reverting to the image default at least creates a stable platform.

A better solution is to move towards using something like vcpkg to get a stable/newer version.

Signed-off-by: GitHub <noreply@github.com>