### PR TITLE
Fixing preprocessor errors on MSVC

### DIFF
--- a/include/amqp.h
+++ b/include/amqp.h
@@ -4,7 +4,11 @@
 #ifndef AMQP_H
 #define AMQP_H
 
-#warning "amqp.h is deprecated, use rabbitmq-c/amqp.h instead."
+#ifdef _MSC_VER
+#   pragma message("warning: amqp.h is deprecated, use rabbitmq-c/amqp.h instead.")
+#else
+#   warning "amqp.h is deprecated, use rabbitmq-c/amqp.h instead."
+#endif
 
 #include <rabbitmq-c/amqp.h>
 

--- a/include/amqp_framing.h
+++ b/include/amqp_framing.h
@@ -5,7 +5,11 @@
 #ifndef AMQP_FRAMING_H
 #define AMQP_FRAMING_H
 
-#warning "amqp_framing.h is deprecated, use rabbitmq-c/framing.h instead.
+#ifdef _MSC_VER
+#   pragma message("warning: amqp_framing.h is deprecated, use rabbitmq-c/framing.h instead.")
+#else
+#   warning "amqp_framing.h is deprecated, use rabbitmq-c/framing.h instead."
+#endif
 
 #include <rabbitmq-c/framing.h>
 

--- a/include/amqp_ssl_socket.h
+++ b/include/amqp_ssl_socket.h
@@ -6,7 +6,11 @@
 #ifndef AMQP_SSL_H
 #define AMQP_SSL_H
 
-#warning "amqp_ssl_socket.h is deprecated, use rabbitmq-c/ssl_socket.h instead.
+#ifdef _MSC_VER
+#   pragma message("warning: amqp_ssl_socket.h is deprecated, use rabbitmq-c/ssl_socket.h instead.")
+#else
+#   warning "amqp_ssl_socket.h is deprecated, use rabbitmq-c/ssl_socket.h instead."
+#endif
 
 #include <rabbitmq-c/ssl_socket.h>
 

--- a/include/amqp_tcp_socket.h
+++ b/include/amqp_tcp_socket.h
@@ -4,7 +4,11 @@
 #ifndef AMQP_TCP_SOCKET_H
 #define AMQP_TCP_SOCKET_H
 
-#warning "amqp_tcp_socket.h is deprecated, use rabbitmq-c/tcp_socket.h instead."
+#ifdef _MSC_VER
+#   pragma message("warning: amqp_tcp_socket.h is deprecated, use rabbitmq-c/tcp_socket.h instead.")
+#else
+#   warning "amqp_tcp_socket.h is deprecated, use rabbitmq-c/tcp_socket.h instead."
+#endif
 
 #include <rabbitmq-c/tcp_socket.h>
 


### PR DESCRIPTION
The VC++ preprocessor cannot handle `#warning` and prevents build.
This is linked with https://github.com/alanxz/SimpleAmqpClient/pull/336.