### PR TITLE
Workaround CI issue with tsan and asan builds failing to run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,11 @@ jobs:
             config: framing
 
     steps:
+      # Workaround issue actions/runner-images#9491
+    - name: modify number of bits to use for aslr entropy
+      run: |
+        sudo sysctl -a | grep vm.mmap.rnd
+        sudo sysctl -w vm.mmap_rnd_bits=28
     - uses: actions/checkout@v2
       with:
         submodules: true


### PR DESCRIPTION
Likely related to actions/runner-images#9491

Signed-off-by: GitHub <noreply@github.com>