### PR TITLE
ssl: use SSL_get1_peer_certificate() in OpenSSL 3

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -215,7 +215,11 @@ start_connect:
     goto error_out2;
   }
 
+#if OPENSSL_VERSION_NUMBER < 0x30000000L
   cert = SSL_get_peer_certificate(self->ssl);
+#else
+  cert = SSL_get1_peer_certificate(self->ssl);
+#endif
 
   if (self->verify_peer) {
     if (!cert) {


### PR DESCRIPTION
The function `SSL_get_peer_certificate()` was deprecated in 3.0.0. Now it is defined as a compatibility macro to `SSL_get1_peer_certificate()`.

However if your OpenSSL 3 is not compiled with the deprecated API included, rabbitmq-c will fail to compile. This commit adds an OpenSSL version check to use the appropriated function.