### PR TITLE
Fix function declaration misalignment warning on OSX

### DIFF
--- a/librabbitmq/amqp_openssl.c
+++ b/librabbitmq/amqp_openssl.c
@@ -627,7 +627,7 @@ out:
 #endif
 }
 
-static int initialize_ssl_and_increment_connections() {
+static int initialize_ssl_and_increment_connections(void) {
   int status;
   CHECK_SUCCESS(pthread_mutex_lock(&openssl_init_mutex));
 


### PR DESCRIPTION
Recent versions of Clang on MacOS X seems to trigger a warning about
"function declaration without a prototype is deprecated in all versions
of C"

Signed-off-by: GitHub <noreply@github.com>