### PR TITLE
Fix typo in amqp-publish.1 manpage.

### DIFF
--- a/tools/doc/amqp-publish.xml
+++ b/tools/doc/amqp-publish.xml
@@ -70,7 +70,7 @@
                         The routing key to publish with.  If omitted,
                         an empty routing key is assumed.  A routing
                         key must be specified when publishing to the
-                        default exchange; in that case, accoding to
+                        default exchange; in that case, according to
                         the AMQP specification, the routing key
                         corresponds to a queue name.
                     </para>


### PR DESCRIPTION
Just forwarding what I found in [Debian's packaging](https://sources.debian.org/src/librabbitmq/0.11.0-1/debian/patches/0004-Fix-typo-in-amqp-publish.1-manpage.patch/).