### PR TITLE
add (void *) cast to amqp_literal_bytes macro

### DIFF
--- a/examples/amqp_confirm_select.c
+++ b/examples/amqp_confirm_select.c
@@ -48,7 +48,7 @@ static void send_batch(amqp_connection_state_t conn, char const *queue_name,
   for (i = 0; i < message_count; i++) {
     uint64_t now = now_microseconds();
 
-    die_on_error(amqp_basic_publish(conn, 1, amqp_cstring_bytes("amq.direct"),
+    die_on_error(amqp_basic_publish(conn, 1, amqp_literal_bytes("amq.direct"),
                                     amqp_cstring_bytes(queue_name), 0, 0, NULL,
                                     message_bytes),
                  "Publishing");

--- a/examples/amqp_producer.c
+++ b/examples/amqp_producer.c
@@ -35,7 +35,7 @@ static void send_batch(amqp_connection_state_t conn, char const *queue_name,
   for (i = 0; i < message_count; i++) {
     uint64_t now = now_microseconds();
 
-    die_on_error(amqp_basic_publish(conn, 1, amqp_cstring_bytes("amq.direct"),
+    die_on_error(amqp_basic_publish(conn, 1, amqp_literal_bytes("amq.direct"),
                                     amqp_cstring_bytes(queue_name), 0, 0, NULL,
                                     message_bytes),
                  "Publishing");

--- a/examples/amqp_rpc_sendstring_client.c
+++ b/examples/amqp_rpc_sendstring_client.c
@@ -85,14 +85,14 @@ int main(int argc, char *argv[]) {
     props._flags = AMQP_BASIC_CONTENT_TYPE_FLAG |
                    AMQP_BASIC_DELIVERY_MODE_FLAG | AMQP_BASIC_REPLY_TO_FLAG |
                    AMQP_BASIC_CORRELATION_ID_FLAG;
-    props.content_type = amqp_cstring_bytes("text/plain");
+    props.content_type = amqp_literal_bytes("text/plain");
     props.delivery_mode = 2; /* persistent delivery mode */
     props.reply_to = amqp_bytes_malloc_dup(reply_to_queue);
     if (props.reply_to.bytes == NULL) {
       fprintf(stderr, "Out of memory while copying queue name");
       return 1;
     }
-    props.correlation_id = amqp_cstring_bytes("1");
+    props.correlation_id = amqp_literal_bytes("1");
 
     /*
       publish

--- a/examples/amqp_sendstring.c
+++ b/examples/amqp_sendstring.c
@@ -54,7 +54,7 @@ int main(int argc, char const *const *argv) {
   {
     amqp_basic_properties_t props;
     props._flags = AMQP_BASIC_CONTENT_TYPE_FLAG | AMQP_BASIC_DELIVERY_MODE_FLAG;
-    props.content_type = amqp_cstring_bytes("text/plain");
+    props.content_type = amqp_literal_bytes("text/plain");
     props.delivery_mode = 2; /* persistent delivery mode */
     die_on_error(amqp_basic_publish(conn, 1, amqp_cstring_bytes(exchange),
                                     amqp_cstring_bytes(routingkey), 0, 0,

--- a/include/rabbitmq-c/amqp.h
+++ b/include/rabbitmq-c/amqp.h
@@ -864,7 +864,7 @@ void AMQP_CALL amqp_pool_alloc_bytes(amqp_pool_t *pool, size_t amount,
  *
  * \since v0.15
  */
-#define amqp_literal_bytes(str) (amqp_bytes_t){sizeof(str) - 1, str}
+#define amqp_literal_bytes(str) (amqp_bytes_t){sizeof(str) - 1, (void *)str}
 
 /**
  * Wraps a c string in an amqp_bytes_t


### PR DESCRIPTION
When adding amqp_literal_bytes macro I forgot about this little know programing language called C++.
In C++ string literals are const qualified by default, so cast from char* to void* is permitted but casts from const void* to void* produce a warning.

This PR fixes warning in C++ and also in C when using -Wwrite-strings