### PR TITLE
support for binary string payload

### DIFF
--- a/include/rabbitmq-c/amqp.h
+++ b/include/rabbitmq-c/amqp.h
@@ -888,6 +888,24 @@ AMQP_EXPORT
 amqp_bytes_t AMQP_CALL amqp_cstring_bytes(char const *cstr);
 
 /**
+ * Wraps a c string in an amqp_bytes_t
+ *
+ * Takes a string, string length and creates an
+ * amqp_bytes_t that points to it. The string is not duplicated.
+ *
+ * For a given input cstr and length, The amqp_bytes_t output.bytes is the
+ * same as cstr, length is the length of the string not including
+ * the \0 terminator
+ *
+ * \param [in] cstr the c string to wrap
+ * \return an amqp_bytes_t that describes the string
+ *
+ * \since v0.16
+ */
+AMQP_EXPORT
+amqp_bytes_t AMQP_CALL amqp_cstring_bytes_with_length(char const *cstr, size_t length);
+
+/**
  * Duplicates an amqp_bytes_t buffer.
  *
  * The buffer is cloned and the contents copied.

--- a/librabbitmq/amqp_mem.c
+++ b/librabbitmq/amqp_mem.c
@@ -138,6 +138,12 @@ amqp_bytes_t amqp_cstring_bytes(char const *cstr) {
   result.bytes = (void *)cstr;
   return result;
 }
+amqp_bytes_t amqp_cstring_bytes_with_length(char const *cstr, size_t length) {
+  amqp_bytes_t result;
+  result.len = length;
+  result.bytes = (void *)cstr;
+  return result;
+}
 
 amqp_bytes_t amqp_bytes_malloc_dup(amqp_bytes_t src) {
   amqp_bytes_t result;


### PR DESCRIPTION
Add amqp_cstring_bytes_with_length function
 
- Introduced amqp_cstring_bytes_with_length to create amqp_bytes_t from a C string with a specified length.
- This function complements amqp_cstring_bytes by allowing more control over the length of the byte array.