### PR TITLE
Fix FILE stream leak in read_authfile()

### DIFF
--- a/tools/common.c
+++ b/tools/common.c
@@ -208,6 +208,7 @@ void read_authfile(const char *path) {
   if (!feof(fp)) {
     die("Malformed auth file (trailing data)");
   }
+  fclose(fp);
 }
 
 static void init_connection_info(struct amqp_connection_info *ci) {


### PR DESCRIPTION
Closes a missing `fclose()` call in `read_authfile()` to avoid a potential file stream leak.

The file opened with `fopen()` was not being explicitly closed, which could lead to resource leaks or issues when processing multiple auth files.

This patch adds the missing `fclose(fp);` at the end of the function.