### PR TITLE
Check calloc() result to prevent NULL dereference

### DIFF
--- a/tools/publish.c
+++ b/tools/publish.c
@@ -91,6 +91,10 @@ int main(int argc, const char **argv) {
       amqp_table_t *table = &props.headers;
       table->num_entries = num;
       table->entries = calloc(num, sizeof(amqp_table_entry_t));
+      if (table->entries == NULL) {
+        fprintf(stderr, "Memory allocation failed\n");
+        return 1;
+      }
       int i = 0;
       for (pos = headers; *pos; pos++) {
         char *colon = strchr(*pos, ':');


### PR DESCRIPTION
This patch adds a check for the result of calloc() in tools/publish.c to avoid a possible NULL pointer dereference in case memory allocation fails.

Dereferencing a NULL pointer would lead to undefined behavior or a crash. This fix ensures that the error is reported and the program exits early, preserving stability.