### PR TITLE
Add malloc() result check in basic_get()

### DIFF
--- a/tests/test_basic.c
+++ b/tests/test_basic.c
@@ -110,6 +110,9 @@ char *basic_get(amqp_connection_state_t connection_state_,
   assert(rpc_reply.reply_type == AMQP_RESPONSE_NORMAL);
 
   char *body = malloc(message.body.len);
+  if (body == NULL) {
+    return NULL;
+  }
   memcpy(body, message.body.bytes, message.body.len);
   *out_body_size_ = message.body.len;
   amqp_destroy_message(&message);
@@ -126,6 +129,7 @@ void publish_and_basic_get_message(const char *msg_to_publish) {
   uint64_t body_size;
   char *msg = basic_get(connection_state, test_queue_name, &body_size);
 
+  assert(msg != NULL && "Test errored: memory allocation failed!");
   assert(body_size == strlen(msg_to_publish));
   assert(strncmp(msg_to_publish, msg, body_size) == 0);
   free(msg);


### PR DESCRIPTION
Check malloc() result in basic_get() before memcpy to avoid NULL dereference.
Add test assertion for allocation failure.