### PR TITLE
Remove unreachable return statement

### DIFF
--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -174,7 +174,6 @@ start_poll:
         return AMQP_STATUS_SOCKET_ERROR;
     }
   }
-  return AMQP_STATUS_OK;
 #elif defined(HAVE_SELECT)
   fd_set fds;
   fd_set exceptfds;


### PR DESCRIPTION
Remove unreachable `return` in amqp_socket.c to clean up dead code.