### PR TITLE
convert amqp_bytes_from_buffer function to macro

### DIFF
--- a/include/rabbitmq-c/amqp.h
+++ b/include/rabbitmq-c/amqp.h
@@ -899,8 +899,7 @@ amqp_bytes_t AMQP_CALL amqp_cstring_bytes(char const *cstr);
  *
  * \since v0.16
  */
-AMQP_EXPORT
-amqp_bytes_t AMQP_CALL amqp_bytes_from_buffer(void const *ptr, size_t length);
+#define amqp_bytes_from_buffer(ptr, length) (amqp_bytes_t){length, (void *)ptr}
 
 /**
  * Duplicates an amqp_bytes_t buffer.

--- a/librabbitmq/amqp_mem.c
+++ b/librabbitmq/amqp_mem.c
@@ -138,12 +138,6 @@ amqp_bytes_t amqp_cstring_bytes(char const *cstr) {
   result.bytes = (void *)cstr;
   return result;
 }
-amqp_bytes_t amqp_bytes_from_buffer(void const *ptr, size_t length) {
-  amqp_bytes_t result;
-  result.len = length;
-  result.bytes = (void *)ptr;
-  return result;
-}
 
 amqp_bytes_t amqp_bytes_malloc_dup(amqp_bytes_t src) {
   amqp_bytes_t result;


### PR DESCRIPTION
This PR converts newly added  amqp_bytes_from_buffer function to macro. This operations is so simple(just setsfields in amqp_bytes_t struct) having done it by function is not optimal. Thus I'm changing it to macro :)

Since version 0.16 is not yet released this is not ABI break.
