### PR TITLE
Fixed external login issues when no identity specified, deprecated varargs methods

### DIFF
--- a/include/rabbitmq-c/amqp.h
+++ b/include/rabbitmq-c/amqp.h
@@ -1662,17 +1662,18 @@ AMQP_EXPORT
 amqp_rpc_reply_t AMQP_CALL amqp_get_rpc_reply(amqp_connection_state_t state);
 
 #if defined(__GNUC__) || defined(__clang__)
-#define DEPRECATED __attribute__((deprecated))
+#define DEPRECATED(msg) __attribute__((deprecated))
 #elif defined(_MSC_VER)
-#define DEPRECATED __declspec(deprecated)
+#define DEPRECATED(msg) __declspec(deprecated)
 #else
-#define DEPRECATED
+#define DEPRECATED(msg)
 #endif
 
 /**
  * Login to the broker
  *
- * DEPRECATED, please use amqp_login_plain() or amqp_login_external()
+ * \deprecated This function is deprecated and should be replaced by a call to
+ * amqp_login_plain() or amqp_login_external()
  *
  * After using amqp_open_socket and amqp_set_sockfd, call
  * amqp_login to complete connecting to the broker
@@ -1732,7 +1733,7 @@ amqp_rpc_reply_t AMQP_CALL amqp_get_rpc_reply(amqp_connection_state_t state);
  *
  * \since v0.1
  */
-AMQP_EXPORT DEPRECATED
+AMQP_EXPORT DEPRECATED("use amqp_login_plain() or amqp_login_external()")
 amqp_rpc_reply_t AMQP_CALL amqp_login(amqp_connection_state_t state,
                                       char const *vhost, int channel_max,
                                       int frame_max, int heartbeat,
@@ -1851,8 +1852,8 @@ amqp_rpc_reply_t AMQP_CALL amqp_login_external(
 /**
  * Login to the broker passing a properties table
  *
- * DEPRECATED, please use amqp_login_plain_with_properties() or
- * amqp_login_external_with_properties()
+ * \deprecated This function is deprecated and should be replaced by a call to
+ * amqp_login_plain_with_properties() or amqp_login_external_with_properties().
  *
  * This function is similar to amqp_login() and differs in that it provides a
  * way to pass client properties to the broker. This is commonly used to
@@ -1915,8 +1916,8 @@ amqp_rpc_reply_t AMQP_CALL amqp_login_external(
  *
  * \since v0.4.0
  */
-AMQP_EXPORT DEPRECATED
-amqp_rpc_reply_t AMQP_CALL amqp_login_with_properties(
+DEPRECATED("use amqp_login_plain_with_properties() or amqp_login_external_with_properties()")
+AMQP_EXPORT amqp_rpc_reply_t AMQP_CALL amqp_login_with_properties(
     amqp_connection_state_t state, char const *vhost, int channel_max,
     int frame_max, int heartbeat, const amqp_table_t *properties,
     amqp_sasl_method_enum sasl_method, ...);
@@ -1975,7 +1976,6 @@ amqp_rpc_reply_t AMQP_CALL amqp_login_with_properties(
  *
  * \since v0.4.0
  */
-AMQP_EXPORT DEPRECATED
 amqp_rpc_reply_t AMQP_CALL amqp_login_plain_with_properties(
     amqp_connection_state_t state, char const *vhost, int channel_max,
     int frame_max, int heartbeat, const amqp_table_t *properties,
@@ -2035,7 +2035,6 @@ amqp_rpc_reply_t AMQP_CALL amqp_login_plain_with_properties(
  *
  * \since v0.4.0
  */
-AMQP_EXPORT DEPRECATED
 amqp_rpc_reply_t AMQP_CALL amqp_login_external_with_properties(
     amqp_connection_state_t state, char const *vhost, int channel_max,
     int frame_max, int heartbeat, const amqp_table_t *properties,

--- a/include/rabbitmq-c/amqp.h
+++ b/include/rabbitmq-c/amqp.h
@@ -1739,7 +1739,7 @@ amqp_rpc_reply_t AMQP_CALL amqp_login(amqp_connection_state_t state,
                                       amqp_sasl_method_enum sasl_method, ...);
 
 /**
-* Login to the broker using the AMQP_SASL_METHOD_PLAIN method
+* Login to the broker using the AMQP_SASL_METHOD_PLAIN SASL method
  *
  * After using amqp_open_socket and amqp_set_sockfd, call
  * amqp_login to complete connecting to the broker
@@ -1794,7 +1794,7 @@ amqp_rpc_reply_t AMQP_CALL amqp_login_plain(
   int frame_max, int heartbeat, const char *username, const char *password);
 
 /**
-* Login to the broker using the AMQP_SASL_METHOD_EXTERNAL method
+* Login to the broker using the AMQP_SASL_METHOD_EXTERNAL SASL method
  *
  * After using amqp_open_socket and amqp_set_sockfd, call
  * amqp_login to complete connecting to the broker
@@ -1922,8 +1922,8 @@ amqp_rpc_reply_t AMQP_CALL amqp_login_with_properties(
     amqp_sasl_method_enum sasl_method, ...);
 
 /**
- * Login to the broker using the AMQP_SASL_METHOD_PLAIN method passing a
- * properties table
+ * Login to the broker using the AMQP_SASL_METHOD_PLAIN SASL method passing in
+ * a properties table
  *
  * This function is similar to amqp_login() and differs in that it provides a
  * way to pass client properties to the broker. This is commonly used to
@@ -1982,8 +1982,8 @@ amqp_rpc_reply_t AMQP_CALL amqp_login_plain_with_properties(
     const char *username, const char *password);
 
 /**
- * Login to the broker using the AMQP_SASL_METHOD_EXTERN method passing a
- * properties table
+ * Login to the broker using the AMQP_SASL_METHOD_EXTERNAL SASL method passing
+ * in a properties table
  *
  * This function is similar to amqp_login() and differs in that it provides a
  * way to pass client properties to the broker. This is commonly used to

--- a/include/rabbitmq-c/amqp.h
+++ b/include/rabbitmq-c/amqp.h
@@ -1661,8 +1661,18 @@ void *AMQP_CALL amqp_simple_rpc_decoded(amqp_connection_state_t state,
 AMQP_EXPORT
 amqp_rpc_reply_t AMQP_CALL amqp_get_rpc_reply(amqp_connection_state_t state);
 
+#if defined(__GNUC__) || defined(__clang__)
+#define DEPRECATED __attribute__((deprecated))
+#elif defined(_MSC_VER)
+#define DEPRECATED __declspec(deprecated)
+#else
+#define DEPRECATED
+#endif
+
 /**
  * Login to the broker
+ *
+ * DEPRECATED, please use amqp_login_plain() or amqp_login_external()
  *
  * After using amqp_open_socket and amqp_set_sockfd, call
  * amqp_login to complete connecting to the broker
@@ -1695,6 +1705,66 @@ amqp_rpc_reply_t AMQP_CALL amqp_get_rpc_reply(amqp_connection_state_t state);
  *              -  AMQP_SASL_METHOD_EXTERNAL, the AMQP_SASL_METHOD_EXTERNAL
  *                 argument should be followed one argument:
  *                 const char* identity.
+ * \param [in] ... either 1 or 2 const char * arguments depending on sasl_method.
+ *              If sasl_method is AMQP_SASL_METHOD_PLAIN then this should be
+ *              const char* username and const char* password.  For
+ *              AMQP_SASL_METHOD_EXTERNAL this should be const char* identity.
+ * \return amqp_rpc_reply_t indicating success or failure.
+ *  - r.reply_type == AMQP_RESPONSE_NORMAL. Login completed successfully
+ *  - r.reply_type == AMQP_RESPONSE_LIBRARY_EXCEPTION. In most cases errors
+ *    from the broker when logging in will be represented by the broker closing
+ *    the socket. In this case r.library_error will be set to
+ *    AMQP_STATUS_CONNECTION_CLOSED. This error can represent a number of
+ *    error conditions including: invalid vhost, authentication failure.
+ *  - r.reply_type == AMQP_RESPONSE_SERVER_EXCEPTION. The broker returned an
+ *    exception:
+ *    - If r.reply.id == AMQP_CHANNEL_CLOSE_METHOD a channel exception
+ *      occurred, cast r.reply.decoded to amqp_channel_close_t* to see details
+ *      of the exception. The client should amqp_send_method() a
+ *      amqp_channel_close_ok_t. The channel must be re-opened before it
+ *      can be used again. Any resources associated with the channel
+ *      (auto-delete exchanges, auto-delete queues, consumers) are invalid
+ *      and must be recreated before attempting to use them again.
+ *    - If r.reply.id == AMQP_CONNECTION_CLOSE_METHOD a connection exception
+ *      occurred, cast r.reply.decoded to amqp_connection_close_t* to see
+ *      details of the exception. The client amqp_send_method() a
+ *      amqp_connection_close_ok_t and disconnect from the broker.
+ *
+ * \since v0.1
+ */
+AMQP_EXPORT DEPRECATED
+amqp_rpc_reply_t AMQP_CALL amqp_login(amqp_connection_state_t state,
+                                      char const *vhost, int channel_max,
+                                      int frame_max, int heartbeat,
+                                      amqp_sasl_method_enum sasl_method, ...);
+
+/**
+* Login to the broker using the AMQP_SASL_METHOD_PLAIN method
+ *
+ * After using amqp_open_socket and amqp_set_sockfd, call
+ * amqp_login to complete connecting to the broker
+ *
+ * \param [in] state the connection object
+ * \param [in] vhost the virtual host to connect to on the broker. The default
+ *              on most brokers is "/"
+ * \param [in] channel_max the limit for number of channels for the connection.
+ *              0 means no limit, and is a good default
+ *              (AMQP_DEFAULT_MAX_CHANNELS)
+ *              Note that the maximum number of channels the protocol supports
+ *              is 65535 (2^16, with the 0-channel reserved). The server can
+ *              set a lower channel_max and then the client will use the lowest
+ *              of the two
+ * \param [in] frame_max the maximum size of an AMQP frame on the wire to
+ *              request of the broker for this connection. 4096 is the minimum
+ *              size, 2^31-1 is the maximum, a good default is 131072 (128KB),
+ *              or AMQP_DEFAULT_FRAME_SIZE
+ * \param [in] heartbeat the number of seconds between heartbeat frames to
+ *              request of the broker. A value of 0 disables heartbeats.
+ *              Note rabbitmq-c only has partial support for heartbeats, as of
+ *              v0.4.0 they are only serviced during amqp_basic_publish() and
+ *              amqp_simple_wait_frame()/amqp_simple_wait_frame_noblock()
+ * \param [in] username the authentication username.
+ * \param [in] password the authentication password.
  * \return amqp_rpc_reply_t indicating success or failure.
  *  - r.reply_type == AMQP_RESPONSE_NORMAL. Login completed successfully
  *  - r.reply_type == AMQP_RESPONSE_LIBRARY_EXCEPTION. In most cases errors
@@ -1719,13 +1789,70 @@ amqp_rpc_reply_t AMQP_CALL amqp_get_rpc_reply(amqp_connection_state_t state);
  * \since v0.1
  */
 AMQP_EXPORT
-amqp_rpc_reply_t AMQP_CALL amqp_login(amqp_connection_state_t state,
-                                      char const *vhost, int channel_max,
-                                      int frame_max, int heartbeat,
-                                      amqp_sasl_method_enum sasl_method, ...);
+amqp_rpc_reply_t AMQP_CALL amqp_login_plain(
+  amqp_connection_state_t state, char const *vhost, int channel_max,
+  int frame_max, int heartbeat, const char *username, const char *password);
+
+/**
+* Login to the broker using the AMQP_SASL_METHOD_EXTERNAL method
+ *
+ * After using amqp_open_socket and amqp_set_sockfd, call
+ * amqp_login to complete connecting to the broker
+ *
+ * \param [in] state the connection object
+ * \param [in] vhost the virtual host to connect to on the broker. The default
+ *              on most brokers is "/"
+ * \param [in] channel_max the limit for number of channels for the connection.
+ *              0 means no limit, and is a good default
+ *              (AMQP_DEFAULT_MAX_CHANNELS)
+ *              Note that the maximum number of channels the protocol supports
+ *              is 65535 (2^16, with the 0-channel reserved). The server can
+ *              set a lower channel_max and then the client will use the lowest
+ *              of the two
+ * \param [in] frame_max the maximum size of an AMQP frame on the wire to
+ *              request of the broker for this connection. 4096 is the minimum
+ *              size, 2^31-1 is the maximum, a good default is 131072 (128KB),
+ *              or AMQP_DEFAULT_FRAME_SIZE
+ * \param [in] heartbeat the number of seconds between heartbeat frames to
+ *              request of the broker. A value of 0 disables heartbeats.
+ *              Note rabbitmq-c only has partial support for heartbeats, as of
+ *              v0.4.0 they are only serviced during amqp_basic_publish() and
+ *              amqp_simple_wait_frame()/amqp_simple_wait_frame_noblock()
+ * \param [in] identity the authentication optional identify.  This can be
+ *              NULL if none.
+ * \return amqp_rpc_reply_t indicating success or failure.
+ *  - r.reply_type == AMQP_RESPONSE_NORMAL. Login completed successfully
+ *  - r.reply_type == AMQP_RESPONSE_LIBRARY_EXCEPTION. In most cases errors
+ *    from the broker when logging in will be represented by the broker closing
+ *    the socket. In this case r.library_error will be set to
+ *    AMQP_STATUS_CONNECTION_CLOSED. This error can represent a number of
+ *    error conditions including: invalid vhost, authentication failure.
+ *  - r.reply_type == AMQP_RESPONSE_SERVER_EXCEPTION. The broker returned an
+ *    exception:
+ *    - If r.reply.id == AMQP_CHANNEL_CLOSE_METHOD a channel exception
+ *      occurred, cast r.reply.decoded to amqp_channel_close_t* to see details
+ *      of the exception. The client should amqp_send_method() a
+ *      amqp_channel_close_ok_t. The channel must be re-opened before it
+ *      can be used again. Any resources associated with the channel
+ *      (auto-delete exchanges, auto-delete queues, consumers) are invalid
+ *      and must be recreated before attempting to use them again.
+ *    - If r.reply.id == AMQP_CONNECTION_CLOSE_METHOD a connection exception
+ *      occurred, cast r.reply.decoded to amqp_connection_close_t* to see
+ *      details of the exception. The client amqp_send_method() a
+ *      amqp_connection_close_ok_t and disconnect from the broker.
+ *
+ * \since v0.1
+ */
+AMQP_EXPORT
+amqp_rpc_reply_t AMQP_CALL amqp_login_external(
+  amqp_connection_state_t state, char const *vhost, int channel_max,
+  int frame_max, int heartbeat, const char *identity);
 
 /**
  * Login to the broker passing a properties table
+ *
+ * DEPRECATED, please use amqp_login_plain_with_properties() or
+ * amqp_login_external_with_properties()
  *
  * This function is similar to amqp_login() and differs in that it provides a
  * way to pass client properties to the broker. This is commonly used to
@@ -1761,6 +1888,10 @@ amqp_rpc_reply_t AMQP_CALL amqp_login(amqp_connection_state_t state,
  *             -  AMQP_SASL_METHOD_EXTERNAL, the AMQP_SASL_METHOD_EXTERNAL
  *                argument should be followed one argument:
  *                const char* identity.
+ * \param [in] ... either 1 or 2 const char * arguments depending on sasl_method.
+ *              If sasl_method is AMQP_SASL_METHOD_PLAIN then this should be
+ *              const char* username and const char* password.  For
+ *              AMQP_SASL_METHOD_EXTERNAL this should be const char* identity.
  * \return amqp_rpc_reply_t indicating success or failure.
  *  - r.reply_type == AMQP_RESPONSE_NORMAL. Login completed successfully
  *  - r.reply_type == AMQP_RESPONSE_LIBRARY_EXCEPTION. In most cases errors
@@ -1784,11 +1915,131 @@ amqp_rpc_reply_t AMQP_CALL amqp_login(amqp_connection_state_t state,
  *
  * \since v0.4.0
  */
-AMQP_EXPORT
+AMQP_EXPORT DEPRECATED
 amqp_rpc_reply_t AMQP_CALL amqp_login_with_properties(
     amqp_connection_state_t state, char const *vhost, int channel_max,
     int frame_max, int heartbeat, const amqp_table_t *properties,
     amqp_sasl_method_enum sasl_method, ...);
+
+/**
+ * Login to the broker using the AMQP_SASL_METHOD_PLAIN method passing a
+ * properties table
+ *
+ * This function is similar to amqp_login() and differs in that it provides a
+ * way to pass client properties to the broker. This is commonly used to
+ * negotiate newer protocol features as they are supported by the broker.
+ *
+ * \param [in] state the connection object
+ * \param [in] vhost the virtual host to connect to on the broker. The default
+ *              on most brokers is "/"
+ * \param [in] channel_max the limit for the number of channels for the
+ *             connection.
+ *             0 means no limit, and is a good default
+ *             (AMQP_DEFAULT_MAX_CHANNELS)
+ *             Note that the maximum number of channels the protocol supports
+ *             is 65535 (2^16, with the 0-channel reserved). The server can
+ *             set a lower channel_max and then the client will use the lowest
+ *             of the two
+ * \param [in] frame_max the maximum size of an AMQP frame ont he wire to
+ *              request of the broker for this connection. 4096 is the minimum
+ *              size, 2^31-1 is the maximum, a good default is 131072 (128KB),
+ *              or AMQP_DEFAULT_FRAME_SIZE
+ * \param [in] heartbeat the number of seconds between heartbeat frame to
+ *             request of the broker. A value of 0 disables heartbeats.
+ *             Note rabbitmq-c only has partial support for hearts, as of
+ *             v0.4.0 heartbeats are only serviced during amqp_basic_publish(),
+ *             and amqp_simple_wait_frame()/amqp_simple_wait_frame_noblock()
+ * \param [in] properties a table of properties to send the broker.
+ * \param [in] username the authentication username.
+ * \param [in] password the authentication password.
+ * \return amqp_rpc_reply_t indicating success or failure.
+ *  - r.reply_type == AMQP_RESPONSE_NORMAL. Login completed successfully
+ *  - r.reply_type == AMQP_RESPONSE_LIBRARY_EXCEPTION. In most cases errors
+ *    from the broker when logging in will be represented by the broker closing
+ *    the socket. In this case r.library_error will be set to
+ *    AMQP_STATUS_CONNECTION_CLOSED. This error can represent a number of
+ *    error conditions including: invalid vhost, authentication failure.
+ *  - r.reply_type == AMQP_RESPONSE_SERVER_EXCEPTION. The broker returned an
+ *    exception:
+ *    - If r.reply.id == AMQP_CHANNEL_CLOSE_METHOD a channel exception
+ *      occurred, cast r.reply.decoded to amqp_channel_close_t* to see details
+ *      of the exception. The client should amqp_send_method() a
+ *      amqp_channel_close_ok_t. The channel must be re-opened before it
+ *      can be used again. Any resources associated with the channel
+ *      (auto-delete exchanges, auto-delete queues, consumers) are invalid
+ *      and must be recreated before attempting to use them again.
+ *    - If r.reply.id == AMQP_CONNECTION_CLOSE_METHOD a connection exception
+ *      occurred, cast r.reply.decoded to amqp_connection_close_t* to see
+ *      details of the exception. The client amqp_send_method() a
+ *      amqp_connection_close_ok_t and disconnect from the broker.
+ *
+ * \since v0.4.0
+ */
+AMQP_EXPORT DEPRECATED
+amqp_rpc_reply_t AMQP_CALL amqp_login_plain_with_properties(
+    amqp_connection_state_t state, char const *vhost, int channel_max,
+    int frame_max, int heartbeat, const amqp_table_t *properties,
+    const char *username, const char *password);
+
+/**
+ * Login to the broker using the AMQP_SASL_METHOD_EXTERN method passing a
+ * properties table
+ *
+ * This function is similar to amqp_login() and differs in that it provides a
+ * way to pass client properties to the broker. This is commonly used to
+ * negotiate newer protocol features as they are supported by the broker.
+ *
+ * \param [in] state the connection object
+ * \param [in] vhost the virtual host to connect to on the broker. The default
+ *              on most brokers is "/"
+ * \param [in] channel_max the limit for the number of channels for the
+ *             connection.
+ *             0 means no limit, and is a good default
+ *             (AMQP_DEFAULT_MAX_CHANNELS)
+ *             Note that the maximum number of channels the protocol supports
+ *             is 65535 (2^16, with the 0-channel reserved). The server can
+ *             set a lower channel_max and then the client will use the lowest
+ *             of the two
+ * \param [in] frame_max the maximum size of an AMQP frame ont he wire to
+ *              request of the broker for this connection. 4096 is the minimum
+ *              size, 2^31-1 is the maximum, a good default is 131072 (128KB),
+ *              or AMQP_DEFAULT_FRAME_SIZE
+ * \param [in] heartbeat the number of seconds between heartbeat frame to
+ *             request of the broker. A value of 0 disables heartbeats.
+ *             Note rabbitmq-c only has partial support for hearts, as of
+ *             v0.4.0 heartbeats are only serviced during amqp_basic_publish(),
+ *             and amqp_simple_wait_frame()/amqp_simple_wait_frame_noblock()
+ * \param [in] properties a table of properties to send the broker.
+ * \param [in] identity the authentication optional identify.  This can be
+ *             NULL if none.
+ * \return amqp_rpc_reply_t indicating success or failure.
+ *  - r.reply_type == AMQP_RESPONSE_NORMAL. Login completed successfully
+ *  - r.reply_type == AMQP_RESPONSE_LIBRARY_EXCEPTION. In most cases errors
+ *    from the broker when logging in will be represented by the broker closing
+ *    the socket. In this case r.library_error will be set to
+ *    AMQP_STATUS_CONNECTION_CLOSED. This error can represent a number of
+ *    error conditions including: invalid vhost, authentication failure.
+ *  - r.reply_type == AMQP_RESPONSE_SERVER_EXCEPTION. The broker returned an
+ *    exception:
+ *    - If r.reply.id == AMQP_CHANNEL_CLOSE_METHOD a channel exception
+ *      occurred, cast r.reply.decoded to amqp_channel_close_t* to see details
+ *      of the exception. The client should amqp_send_method() a
+ *      amqp_channel_close_ok_t. The channel must be re-opened before it
+ *      can be used again. Any resources associated with the channel
+ *      (auto-delete exchanges, auto-delete queues, consumers) are invalid
+ *      and must be recreated before attempting to use them again.
+ *    - If r.reply.id == AMQP_CONNECTION_CLOSE_METHOD a connection exception
+ *      occurred, cast r.reply.decoded to amqp_connection_close_t* to see
+ *      details of the exception. The client amqp_send_method() a
+ *      amqp_connection_close_ok_t and disconnect from the broker.
+ *
+ * \since v0.4.0
+ */
+AMQP_EXPORT DEPRECATED
+amqp_rpc_reply_t AMQP_CALL amqp_login_external_with_properties(
+    amqp_connection_state_t state, char const *vhost, int channel_max,
+    int frame_max, int heartbeat, const amqp_table_t *properties,
+    const char *identity);
 
 struct amqp_basic_properties_t_;
 

--- a/include/rabbitmq-c/amqp.h
+++ b/include/rabbitmq-c/amqp.h
@@ -1733,14 +1733,15 @@ amqp_rpc_reply_t AMQP_CALL amqp_get_rpc_reply(amqp_connection_state_t state);
  *
  * \since v0.1
  */
-AMQP_EXPORT DEPRECATED("use amqp_login_plain() or amqp_login_external()")
+DEPRECATED("use amqp_login_plain() or amqp_login_external()")
+AMQP_EXPORT
 amqp_rpc_reply_t AMQP_CALL amqp_login(amqp_connection_state_t state,
                                       char const *vhost, int channel_max,
                                       int frame_max, int heartbeat,
                                       amqp_sasl_method_enum sasl_method, ...);
 
 /**
-* Login to the broker using the AMQP_SASL_METHOD_PLAIN SASL method
+ * Login to the broker using the AMQP_SASL_METHOD_PLAIN SASL method
  *
  * After using amqp_open_socket and amqp_set_sockfd, call
  * amqp_login to complete connecting to the broker
@@ -1795,7 +1796,7 @@ amqp_rpc_reply_t AMQP_CALL amqp_login_plain(
   int frame_max, int heartbeat, const char *username, const char *password);
 
 /**
-* Login to the broker using the AMQP_SASL_METHOD_EXTERNAL SASL method
+ * Login to the broker using the AMQP_SASL_METHOD_EXTERNAL SASL method
  *
  * After using amqp_open_socket and amqp_set_sockfd, call
  * amqp_login to complete connecting to the broker
@@ -1917,7 +1918,8 @@ amqp_rpc_reply_t AMQP_CALL amqp_login_external(
  * \since v0.4.0
  */
 DEPRECATED("use amqp_login_plain_with_properties() or amqp_login_external_with_properties()")
-AMQP_EXPORT amqp_rpc_reply_t AMQP_CALL amqp_login_with_properties(
+AMQP_EXPORT
+amqp_rpc_reply_t AMQP_CALL amqp_login_with_properties(
     amqp_connection_state_t state, char const *vhost, int channel_max,
     int frame_max, int heartbeat, const amqp_table_t *properties,
     amqp_sasl_method_enum sasl_method, ...);

--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -567,24 +567,26 @@ int sasl_mechanism_in_list(amqp_bytes_t mechanisms,
   return 0;
 }
 
+/*
+ * Build the response buffer.  Returns a amqp_bytes_t len of -1 on memory errors.
+ */
 static amqp_bytes_t sasl_response(amqp_pool_t *pool,
-                                  amqp_sasl_method_enum method, va_list args) {
+  amqp_sasl_method_enum method, const char *username, const char *password,
+  const char *identity) {
   amqp_bytes_t response;
 
   switch (method) {
     case AMQP_SASL_METHOD_PLAIN: {
-      char *username = va_arg(args, char *);
       size_t username_len = strlen(username);
-      char *password = va_arg(args, char *);
       size_t password_len = strlen(password);
       char *response_buf;
 
       amqp_pool_alloc_bytes(pool, strlen(username) + strlen(password) + 2,
                             &response);
-      if (response.bytes == NULL)
-      /* We never request a zero-length block, because of the +2
-         above, so a NULL here really is ENOMEM. */
-      {
+      if (response.bytes == NULL) {
+        /* We never request a zero-length block, because of the +2
+           above, so a NULL here really is ENOMEM so we return len of -1. */
+        response.len = -1;
         return response;
       }
 
@@ -596,11 +598,14 @@ static amqp_bytes_t sasl_response(amqp_pool_t *pool,
       break;
     }
     case AMQP_SASL_METHOD_EXTERNAL: {
-      char *identity = va_arg(args, char *);
-      size_t identity_len = strlen(identity);
+      size_t identity_len = 0;
+      if (identity != NULL) {
+        identity_len = strlen(identity);
+      }
 
       amqp_pool_alloc_bytes(pool, identity_len, &response);
       if (response.bytes == NULL) {
+        // identity could be NULL (or "") here so this could be a valid response
         return response;
       }
 
@@ -1205,7 +1210,9 @@ static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
                                          const amqp_table_t *client_properties,
                                          const struct timeval *timeout,
                                          amqp_sasl_method_enum sasl_method,
-                                         va_list vl) {
+                                         const char *username,
+                                         const char *password,
+                                         const char *identity) {
   int res;
   amqp_method_t method;
 
@@ -1290,8 +1297,10 @@ static amqp_rpc_reply_t amqp_login_inner(amqp_connection_state_t state,
       goto error_res;
     }
 
-    response_bytes = sasl_response(channel_pool, sasl_method, vl);
-    if (response_bytes.bytes == NULL) {
+    response_bytes = sasl_response(channel_pool, sasl_method, username,
+      password, identity);
+    // NOTE: response_bytes.bytes can be NULL if the idenity is NULL or ""
+    if (response_bytes.len < 0) {
       res = AMQP_STATUS_NO_MEMORY;
       goto error_res;
     }
@@ -1438,16 +1447,44 @@ amqp_rpc_reply_t amqp_login(amqp_connection_state_t state, char const *vhost,
 
   va_list vl;
   amqp_rpc_reply_t ret;
+  char *username, *password, *identity;
 
   va_start(vl, sasl_method);
-
-  ret = amqp_login_inner(state, vhost, channel_max, frame_max, heartbeat,
-                         &amqp_empty_table, state->handshake_timeout,
-                         sasl_method, vl);
-
+  if (sasl_method == AMQP_SASL_METHOD_PLAIN) {
+    username = va_arg(vl, char *);
+    password = va_arg(vl, char *);
+  } else if (sasl_method == AMQP_SASL_METHOD_EXTERNAL) {
+    identity = va_arg(vl, char *);
+  }
   va_end(vl);
 
-  return ret;
+  if (sasl_method == AMQP_SASL_METHOD_PLAIN) {
+    return amqp_login_inner(state, vhost, channel_max, frame_max, heartbeat,
+                            &amqp_empty_table, state->handshake_timeout,
+                            AMQP_SASL_METHOD_PLAIN, username, password, NULL);
+  } else if (sasl_method == AMQP_SASL_METHOD_EXTERNAL) {
+    return amqp_login_inner(state, vhost, channel_max, frame_max, heartbeat,
+                            &amqp_empty_table, state->handshake_timeout,
+                            AMQP_SASL_METHOD_EXTERNAL, NULL, NULL, identity);
+  } else {
+    return amqp_rpc_reply_error(AMQP_RESPONSE_LIBRARY_EXCEPTION);
+  }
+}
+
+amqp_rpc_reply_t amqp_login_plain(
+    amqp_connection_state_t state, char const *vhost, int channel_max,
+    int frame_max, int heartbeat, const char *username, const char *password) {
+  return amqp_login_inner(state, vhost, channel_max, frame_max, heartbeat,
+                          &amqp_empty_table, state->handshake_timeout,
+                          AMQP_SASL_METHOD_PLAIN, username, password, NULL);
+}
+
+amqp_rpc_reply_t amqp_login_external(
+    amqp_connection_state_t state, char const *vhost, int channel_max,
+    int frame_max, int heartbeat, const char *identity) {
+  return amqp_login_inner(state, vhost, channel_max, frame_max, heartbeat,
+                          &amqp_empty_table, state->handshake_timeout,
+                          AMQP_SASL_METHOD_EXTERNAL, NULL, NULL, identity);
 }
 
 amqp_rpc_reply_t amqp_login_with_properties(
@@ -1456,14 +1493,44 @@ amqp_rpc_reply_t amqp_login_with_properties(
     amqp_sasl_method_enum sasl_method, ...) {
   va_list vl;
   amqp_rpc_reply_t ret;
+  char *username, *password, *identity;
 
   va_start(vl, sasl_method);
-
-  ret = amqp_login_inner(state, vhost, channel_max, frame_max, heartbeat,
-                         client_properties, state->handshake_timeout,
-                         sasl_method, vl);
-
+  if (sasl_method == AMQP_SASL_METHOD_PLAIN) {
+    username = va_arg(vl, char *);
+    password = va_arg(vl, char *);
+  } else if (sasl_method == AMQP_SASL_METHOD_EXTERNAL) {
+    identity = va_arg(vl, char *);
+  }
   va_end(vl);
 
-  return ret;
+  if (sasl_method == AMQP_SASL_METHOD_PLAIN) {
+    return amqp_login_inner(state, vhost, channel_max, frame_max, heartbeat,
+                            client_properties, state->handshake_timeout,
+                            AMQP_SASL_METHOD_PLAIN, username, password, NULL);
+  } else if (sasl_method == AMQP_SASL_METHOD_EXTERNAL) {
+    return amqp_login_inner(state, vhost, channel_max, frame_max, heartbeat,
+                            client_properties, state->handshake_timeout,
+                            AMQP_SASL_METHOD_EXTERNAL, NULL, NULL, identity);
+  } else {
+    return amqp_rpc_reply_error(AMQP_RESPONSE_LIBRARY_EXCEPTION);
+  }
+}
+
+amqp_rpc_reply_t amqp_login_plain_with_properties(
+    amqp_connection_state_t state, char const *vhost, int channel_max,
+    int frame_max, int heartbeat, const amqp_table_t *client_properties,
+    const char *username, const char *password) {
+  return amqp_login_inner(state, vhost, channel_max, frame_max, heartbeat,
+                          client_properties, state->handshake_timeout,
+                          AMQP_SASL_METHOD_PLAIN, username, password, NULL);
+}
+
+amqp_rpc_reply_t amqp_login_external_with_properties(
+    amqp_connection_state_t state, char const *vhost, int channel_max,
+    int frame_max, int heartbeat, const amqp_table_t *client_properties,
+    const char *identity) {
+  return amqp_login_inner(state, vhost, channel_max, frame_max, heartbeat,
+                          client_properties, state->handshake_timeout,
+                          AMQP_SASL_METHOD_EXTERNAL, NULL, NULL, identity);
 }

--- a/tests/test_basic.c
+++ b/tests/test_basic.c
@@ -36,6 +36,10 @@ amqp_connection_state_t setup_connection_and_channel(void) {
       connection_state_, "/", 1, AMQP_DEFAULT_FRAME_SIZE,
       AMQP_DEFAULT_HEARTBEAT, AMQP_SASL_METHOD_PLAIN, "guest", "guest");
   assert(rpc_reply.reply_type == AMQP_RESPONSE_NORMAL);
+  rpc_reply = amqp_login_plain(
+      connection_state_, "/", 1, AMQP_DEFAULT_FRAME_SIZE,
+      AMQP_DEFAULT_HEARTBEAT, "guest", "guest");
+  assert(rpc_reply.reply_type == AMQP_RESPONSE_NORMAL);
 
   amqp_channel_open_ok_t *res =
       amqp_channel_open(connection_state_, fixed_channel_id);


### PR DESCRIPTION
We recently found a problem with the amqp_login() method when dealing with EXTERNAL sasl_method.  We were trying to pass in NULL or "" as the identity argument which was returning a NO_MEMORY error.  The developer then made the unfortunate decision to not pass in any arguments which worked but only because of some random bytes on the argument stack.

I've made it so NULL or "" is now allowed to be passed into amqp_login() as the first argument with the EXTERNAL sasl_method and I added amqp_login_plain() and _external() methods as well as the with_properties() variants and deprecated the varargs ones.

Thanks.
