### PR TITLE
tools: support AMQP_URL environment variable as connection default

### DIFF
--- a/tools/common.c
+++ b/tools/common.c
@@ -140,8 +140,8 @@ static char *amqp_cert = NULL;
 
 const char *connect_options_title = "Connection options";
 struct poptOption connect_options[] = {
-    {"url", 'u', POPT_ARG_STRING, &amqp_url, 0, "the AMQP URL to connect to",
-     "amqp://..."},
+    {"url", 'u', POPT_ARG_STRING, &amqp_url, 0,
+     "the AMQP URL to connect to (overrides AMQP_URL env var)", "amqp://..."},
     {"server", 's', POPT_ARG_STRING, &amqp_server, 0,
      "the AMQP server to connect to", "hostname"},
     {"port", 0, POPT_ARG_INT, &amqp_port, 0, "the port to connect on", "port"},
@@ -220,6 +220,17 @@ static void init_connection_info(struct amqp_connection_info *ci) {
   ci->user = NULL;
 
   amqp_default_connection_info(ci);
+
+  /* If no connection options were given on the CLI, fall back to AMQP_URL env
+   * var. Any explicit CLI connection flag takes full precedence and bypasses
+   * the env var entirely. */
+  if (!amqp_url && !amqp_server && amqp_port < 0 && !amqp_username &&
+      !amqp_password && !amqp_vhost) {
+    const char *env_url = getenv("AMQP_URL");
+    if (env_url) {
+      amqp_url = (char *)env_url;
+    }
+  }
 
   if (amqp_url)
     die_amqp_error(amqp_parse_url(strdup(amqp_url), ci), "Parsing URL '%s'",

--- a/tools/doc/librabbitmq-tools.xml
+++ b/tools/doc/librabbitmq-tools.xml
@@ -38,6 +38,18 @@
         <title>Common Options</title>
         <variablelist>
             <varlistentry>
+                <term><option>-u</option></term>
+                <term><option>--url</option>=<replaceable class="parameter">amqp://...</replaceable></term>
+                <listitem>
+                    <para>
+                        The AMQP URL to connect to. Takes precedence
+                        over the <envar>AMQP_URL</envar> environment
+                        variable. If neither is given, the default
+                        connection parameters are used.
+                    </para>
+                </listitem>
+            </varlistentry>
+            <varlistentry>
                 <term><option>-s</option></term>
                 <term><option>--server</option>=<replaceable class="parameter">hostname:port</replaceable></term>
                 <listitem>
@@ -71,6 +83,28 @@
                 <listitem>
                     <para>
                         The password to authenticate to the AMQP server with.  Defaults to <literal>guest</literal>.
+                    </para>
+                </listitem>
+            </varlistentry>
+        </variablelist>
+    </refsect1>
+
+    <refsect1>
+        <title>Environment Variables</title>
+        <variablelist>
+            <varlistentry>
+                <term><envar>AMQP_URL</envar></term>
+                <listitem>
+                    <para>
+                        Specifies the default AMQP URL to connect to.
+                        Ignored if any connection option
+                        (<option>--url</option>,
+                        <option>--server</option>,
+                        <option>--port</option>,
+                        <option>--username</option>,
+                        <option>--password</option>, or
+                        <option>--vhost</option>) is given on the
+                        command line.
                     </para>
                 </listitem>
             </varlistentry>


### PR DESCRIPTION
Closes #871

## Summary

If none of `--url`, `--server`, `--port`, `--username`, `--password`, or `--vhost` are provided on the command line, the tools now read `AMQP_URL` from the environment as the connection URL.

Any explicit CLI connection flag takes **full precedence** and bypasses the env var entirely — no error is raised, the env var is simply ignored. This follows the standard Unix convention that env vars express defaults (like `$http_proxy`, `$PGHOST`, `$PAGER`) while CLI flags are explicit overrides.

```sh
# Uses AMQP_URL when no connection flags given
export AMQP_URL=amqp://user:pass@prod-host/vhost
amqp-publish --exchange=foo --routing-key=bar

# CLI flags take over entirely; AMQP_URL is silently ignored
amqp-publish --server=staging-host --exchange=foo --routing-key=bar
```

## Changes

**`tools/common.c`**
- Updated `--url`/`-u` help text to mention `AMQP_URL`
- Added env var fallback in `init_connection_info()`, guarded so it only applies when no CLI connection option was given:
  ```c
  if (!amqp_url && !amqp_server && amqp_port < 0 &&
      !amqp_username && !amqp_password && !amqp_vhost) {
      const char *env_url = getenv("AMQP_URL");
      if (env_url) {
          amqp_url = (char *)env_url;
      }
  }
  ```

**`tools/doc/librabbitmq-tools.xml`**
- Added `--url`/`-u` to the Common Options section (it was previously undocumented)
- Added a new Environment Variables section documenting `AMQP_URL` and its precedence rules