### PR TITLE
OSS-Fuzz: Add new fuzzer for property decode

### DIFF
--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -20,4 +20,7 @@ if(BUILD_OSSFUZZ)
 
   add_executable(fuzz_method_decode fuzz_method_decode.c)
   target_link_libraries(fuzz_method_decode rabbitmq-static)
+
+  add_executable(fuzz_properties_decode fuzz_properties_decode.c)
+  target_link_libraries(fuzz_properties_decode rabbitmq-static)
 endif ()

--- a/fuzz/fuzz_properties_decode.c
+++ b/fuzz/fuzz_properties_decode.c
@@ -1,0 +1,42 @@
+// Copyright 2007 - 2026, Arthur Chan and the rabbitmq-c contributors.
+// SPDX-License-Identifier: mit
+
+#include <errno.h>
+#include <inttypes.h>
+#include <math.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <rabbitmq-c/amqp.h>
+#include <rabbitmq-c/framing.h>
+
+// Drives amqp_decode_properties(), the generated decoder for every AMQP
+// content-header (properties) frame. The first 2 bytes are the class id
+// (big-endian), the rest the body.
+extern int LLVMFuzzerTestOneInput(const char *data, size_t size) {
+
+  int unused_result;
+  amqp_pool_t pool;
+  uint16_t class_id;
+
+  if (size < 2) {
+    return 0;
+  }
+
+  class_id = ((uint16_t)(uint8_t)data[0] << 8) |
+             ((uint16_t)(uint8_t)data[1]);
+
+  init_amqp_pool(&pool, 4096);
+  {
+    void *decoded = NULL;
+    amqp_bytes_t encoded;
+    encoded.len = size - 2;
+    encoded.bytes = (void *)(data + 2);
+
+    unused_result = amqp_decode_properties(class_id, &pool, encoded, &decoded);
+  }
+  empty_amqp_pool(&pool);
+  return 0;
+}


### PR DESCRIPTION
This PR adds a new oss-fuzz fuzzer targets property decoding process, the build from oss-fuzz side is also fixed (https://github.com/google/oss-fuzz/pull/15672).