### PR TITLE
Fix UB in amqp_decode_properties flag word shift

### DIFF
--- a/librabbitmq/amqp_framing.c
+++ b/librabbitmq/amqp_framing.c
@@ -1419,7 +1419,7 @@ int amqp_decode_properties(uint16_t class_id, amqp_pool_t *pool,
   do {
     if (!amqp_decode_16(encoded, &offset, &partial_flags))
       return AMQP_STATUS_BAD_AMQP_DATA;
-    flags |= (partial_flags << (flagword_index * 16));
+    flags |= ((amqp_flags_t)partial_flags << (flagword_index * 16));
     flagword_index++;
   } while (partial_flags & 1);
 

--- a/librabbitmq/codegen.py
+++ b/librabbitmq/codegen.py
@@ -394,7 +394,7 @@ int amqp_decode_properties(uint16_t class_id,
   do {
     if (!amqp_decode_16(encoded, &offset, &partial_flags))
       return AMQP_STATUS_BAD_AMQP_DATA;
-    flags |= (partial_flags << (flagword_index * 16));
+    flags |= ((amqp_flags_t)partial_flags << (flagword_index * 16));
     flagword_index++;
   } while (partial_flags & 1);
 


### PR DESCRIPTION
## Problem

`fuzz_properties_decode` triggers a UBSan error:

```
librabbitmq/amqp_framing.c:1422:29: runtime error: left shift of 65312 by 16 places cannot be represented in type 'int'
```

In `amqp_decode_properties`, `partial_flags` is a `uint16_t`. In the expression `partial_flags << (flagword_index * 16)`, `partial_flags` undergoes integer promotion to `int` before the shift. When `flagword_index` is 1 the shift is by 16, and a value like `65312 << 16` sets bits in (and past) the sign bit of a 32-bit signed `int` — undefined behavior.

## Fix

Cast `partial_flags` to `amqp_flags_t` (`uint32_t`) before shifting, so the shift is performed on an unsigned 32-bit type where the behavior is well-defined.

Since `librabbitmq/amqp_framing.c` is generated, the corresponding template in `librabbitmq/codegen.py` (which `regenerate_framing.sh` runs) is updated to match.

https://claude.ai/code/session_01GS824gxH8fXwKKmYg3S6uh

---
_Generated by [Claude Code](https://claude.ai/code/session_01GS824gxH8fXwKKmYg3S6uh)_