### PR TITLE
Fix UB in amqp_decode_properties by reading a single property flag word

### DIFF
--- a/librabbitmq/amqp_framing.c
+++ b/librabbitmq/amqp_framing.c
@@ -1413,15 +1413,16 @@ int amqp_decode_properties(uint16_t class_id, amqp_pool_t *pool,
   size_t offset = 0;
 
   amqp_flags_t flags = 0;
-  int flagword_index = 0;
   uint16_t partial_flags;
 
-  do {
-    if (!amqp_decode_16(encoded, &offset, &partial_flags))
-      return AMQP_STATUS_BAD_AMQP_DATA;
-    flags |= ((amqp_flags_t)partial_flags << (flagword_index * 16));
-    flagword_index++;
-  } while (partial_flags & 1);
+  if (!amqp_decode_16(encoded, &offset, &partial_flags))
+    return AMQP_STATUS_BAD_AMQP_DATA;
+  /* No AMQP 0-9-1 class defines more than 14 properties, so all property
+     flags fit in a single 16-bit flag word. Bit 0 is the continuation bit;
+     if it is set the message declares further flag words, which we do not
+     support, so reject the frame rather than misinterpret it. */
+  if (partial_flags & 1) return AMQP_STATUS_BAD_AMQP_DATA;
+  flags = partial_flags;
 
   switch (class_id) {
     case 10: {

--- a/librabbitmq/codegen.py
+++ b/librabbitmq/codegen.py
@@ -388,15 +388,16 @@ int amqp_decode_properties(uint16_t class_id,
   size_t offset = 0;
 
   amqp_flags_t flags = 0;
-  int flagword_index = 0;
   uint16_t partial_flags;
 
-  do {
-    if (!amqp_decode_16(encoded, &offset, &partial_flags))
-      return AMQP_STATUS_BAD_AMQP_DATA;
-    flags |= ((amqp_flags_t)partial_flags << (flagword_index * 16));
-    flagword_index++;
-  } while (partial_flags & 1);
+  if (!amqp_decode_16(encoded, &offset, &partial_flags))
+    return AMQP_STATUS_BAD_AMQP_DATA;
+  /* No AMQP 0-9-1 class defines more than 14 properties, so all property
+     flags fit in a single 16-bit flag word. Bit 0 is the continuation bit;
+     if it is set the message declares further flag words, which we do not
+     support, so reject the frame rather than misinterpret it. */
+  if (partial_flags & 1) return AMQP_STATUS_BAD_AMQP_DATA;
+  flags = partial_flags;
 
   switch (class_id) {""")
     for c in spec.allClasses(): genDecodeProperties(c)


### PR DESCRIPTION
## Summary

Fixes the undefined behavior caught by OSS-Fuzz / UBSan in `amqp_decode_properties`:

```
amqp_framing.c:1422:43: runtime error: shift exponent 32 is too large for 32-bit type 'amqp_flags_t' (aka 'unsigned int')
```

## Root cause

Content-header property flags are encoded as a sequence of 16-bit words where **bit 0 of each word is a continuation bit** — if set, another flag word follows. The decoder accumulated each word into a 32-bit `amqp_flags_t` by shifting it left by `flagword_index * 16`:

```c
do {
  if (!amqp_decode_16(encoded, &offset, &partial_flags))
    return AMQP_STATUS_BAD_AMQP_DATA;
  flags |= ((amqp_flags_t)partial_flags << (flagword_index * 16));
  flagword_index++;
} while (partial_flags & 1);
```

A crafted frame that keeps the continuation bit set drives `flagword_index` to `2`, producing `partial_flags << 32` — a shift equal to the width of the type, which is undefined behavior.

## Fix

No AMQP 0-9-1 class defines more than 14 properties, so the property flags always fit in a **single 16-bit flag word**. The multi-word accumulation loop is replaced with a single `amqp_decode_16`, and the frame is rejected with `AMQP_STATUS_BAD_AMQP_DATA` if the continuation bit is set:

```c
amqp_flags_t flags = 0;
uint16_t partial_flags;

if (!amqp_decode_16(encoded, &offset, &partial_flags))
  return AMQP_STATUS_BAD_AMQP_DATA;
/* No AMQP 0-9-1 class defines more than 14 properties, so all property
   flags fit in a single 16-bit flag word. Bit 0 is the continuation bit;
   if it is set the message declares further flag words, which we do not
   support, so reject the frame rather than misinterpret it. */
if (partial_flags & 1) return AMQP_STATUS_BAD_AMQP_DATA;
flags = partial_flags;
```

This removes the variable shift entirely — so the UB is structurally eliminated, not just bounded — and simplifies the decoder. `codegen.py`, which generates `amqp_framing.c`, is updated to match so regenerating keeps the source in sync.

## Verification

- Reproduced the decode logic in isolation under `-fsanitize=undefined`: a single flag word with no continuation decodes correctly, and a word with the continuation bit set is rejected with no UB.
- CI is green, including `build-linux (clang, format)` and `build-linux (clang, framing)` (which confirms `amqp_framing.c` matches the `codegen.py` generator).

## Resolves

- https://issues.oss-fuzz.com/524134808
- https://issues.oss-fuzz.com/524518094

🤖 Generated with [Claude Code](https://claude.com/claude-code)