### PR TITLE
Fix size_t overflow in amqp_decode_bytes bounds check (GHSA-jgjf-7fwf-f3c7)

### DIFF
--- a/librabbitmq/amqp_private.h
+++ b/librabbitmq/amqp_private.h
@@ -299,7 +299,10 @@ static inline int amqp_encode_bytes(amqp_bytes_t encoded, size_t *offset,
   if (input.len == 0) {
     return 1;
   }
-  if ((*offset = o + input.len) <= encoded.len) {
+  *offset = o + input.len;
+  /* Compare against remaining space rather than o + input.len to avoid size_t
+   * overflow; o <= encoded.len, so encoded.len - o cannot underflow. */
+  if (o <= encoded.len && input.len <= encoded.len - o) {
     memcpy(amqp_offset(encoded.bytes, o), input.bytes, input.len);
     return 1;
   } else {
@@ -310,7 +313,12 @@ static inline int amqp_encode_bytes(amqp_bytes_t encoded, size_t *offset,
 static inline int amqp_decode_bytes(amqp_bytes_t encoded, size_t *offset,
                                     amqp_bytes_t *output, size_t len) {
   size_t o = *offset;
-  if ((*offset = o + len) <= encoded.len) {
+  *offset = o + len;
+  /* Compare against remaining space rather than o + len: with len read from the
+   * wire (uint32_t), o + len can overflow size_t on 32-bit platforms and wrap
+   * past the check, yielding an out-of-bounds amqp_bytes_t. o <= encoded.len,
+   * so encoded.len - o cannot underflow. */
+  if (o <= encoded.len && len <= encoded.len - o) {
     output->bytes = amqp_offset(encoded.bytes, o);
     output->len = len;
     return 1;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -48,3 +48,7 @@ add_test(merge_capabilities test_merge_capabilities)
 add_executable(test_send_frame test_send_frame.c)
 target_link_libraries(test_send_frame rabbitmq-static)
 add_test(send_frame test_send_frame)
+
+add_executable(test_decode_bytes test_decode_bytes.c)
+target_link_libraries(test_decode_bytes rabbitmq-static)
+add_test(decode_bytes test_decode_bytes)

--- a/tests/test_decode_bytes.c
+++ b/tests/test_decode_bytes.c
@@ -1,0 +1,84 @@
+// Copyright 2007 - 2021, Alan Antonuk and the rabbitmq-c contributors.
+// SPDX-License-Identifier: mit
+
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "amqp_private.h"
+
+/* Regression test for GHSA-jgjf-7fwf-f3c7: a size_t integer overflow in
+ * amqp_decode_bytes bypassed the bounds check on 32-bit systems, producing an
+ * out-of-bounds amqp_bytes_t (information disclosure / crash). The check must
+ * reject any (offset, len) pair that would read past the end of the buffer,
+ * including ones where offset + len wraps around SIZE_MAX. */
+
+static int failures = 0;
+
+static void expect_reject(const char *name, amqp_bytes_t encoded, size_t offset,
+                          size_t len) {
+  amqp_bytes_t output;
+  size_t off = offset;
+  output.bytes = NULL;
+  output.len = 0;
+  if (amqp_decode_bytes(encoded, &off, &output, len)) {
+    fprintf(stderr,
+            "FAIL %s: amqp_decode_bytes accepted an out-of-bounds length "
+            "(offset=%zu len=%zu buffer=%zu) -> output.len=%zu\n",
+            name, offset, len, encoded.len, output.len);
+    failures++;
+  }
+}
+
+static void expect_accept(const char *name, amqp_bytes_t encoded, size_t offset,
+                          size_t len) {
+  amqp_bytes_t output;
+  size_t off = offset;
+  output.bytes = NULL;
+  output.len = 0;
+  if (!amqp_decode_bytes(encoded, &off, &output, len)) {
+    fprintf(stderr,
+            "FAIL %s: amqp_decode_bytes rejected a valid length "
+            "(offset=%zu len=%zu buffer=%zu)\n",
+            name, offset, len, encoded.len);
+    failures++;
+    return;
+  }
+  if (output.len != len || output.bytes != amqp_offset(encoded.bytes, offset)) {
+    fprintf(stderr, "FAIL %s: amqp_decode_bytes produced wrong output\n", name);
+    failures++;
+  }
+}
+
+int main(void) {
+  char buffer[16];
+  amqp_bytes_t encoded;
+  encoded.bytes = buffer;
+  encoded.len = sizeof(buffer);
+
+  /* Normal, in-bounds decodes still work. */
+  expect_accept("full buffer", encoded, 0, sizeof(buffer));
+  expect_accept("partial at offset", encoded, 4, 8);
+  expect_accept("zero length", encoded, 8, 0);
+
+  /* Plain out-of-bounds (no overflow) is rejected. */
+  expect_reject("len past end", encoded, 0, sizeof(buffer) + 1);
+  expect_reject("offset past end", encoded, sizeof(buffer) + 1, 0);
+
+  /* The core of the advisory: a wire length large enough that offset + len
+   * wraps around SIZE_MAX. On 32-bit platforms a uint32_t length of
+   * 0xFFFFFFF5 with a small offset wraps to a tiny value; on any platform we
+   * can force the wrap with a len near SIZE_MAX. Both must be rejected rather
+   * than producing a multi-gigabyte amqp_bytes_t into a small buffer. */
+  expect_reject("overflow to zero", encoded, 11, (size_t)0 - 11);
+  expect_reject("overflow wraps small", encoded, 16, (size_t)0 - 8);
+  expect_reject("max len", encoded, 1, (size_t)-1);
+  expect_reject("32-bit style len", encoded, 11, (size_t)0xFFFFFFF5u);
+
+  if (failures) {
+    fprintf(stderr, "%d test(s) failed\n", failures);
+    return 1;
+  }
+  printf("all amqp_decode_bytes bounds tests passed\n");
+  return 0;
+}


### PR DESCRIPTION
## Summary

Fixes the size_t integer overflow reported in [GHSA-jgjf-7fwf-f3c7](https://github.com/alanxz/rabbitmq-c/security/advisories/GHSA-jgjf-7fwf-f3c7).

`amqp_decode_bytes` (in `librabbitmq/amqp_private.h`) validated a decoded BYTES/UTF8 field with:

```c
if ((*offset = o + len) <= encoded.len) { ... }
```

`len` is a `uint32_t` read straight from the AMQP wire. When `o + len` exceeds `SIZE_MAX` the addition wraps around `size_t`. On **32-bit** platforms an attacker-controlled length such as `0xFFFFFFF5` with a small offset wraps the sum to a tiny value that passes the check, yielding an `amqp_bytes_t` with a multi-gigabyte `.len` pointing into a small frame buffer. Subsequent processing (e.g. `amqp_table_clone`, logging, comparison) then reads up to ~4 GB out of bounds — information disclosure or crash. 64-bit builds are unaffected, which is why OSS-Fuzz (64-bit only) never caught it.

## Fix

Compare `len` against the *remaining* space instead of computing the sum:

```c
if (o <= encoded.len && len <= encoded.len - o) { ... }
```

`encoded.len - o` cannot underflow because `o <= encoded.len`, and no addition can overflow, so the check is correct on all word sizes. The same hardening is applied to `amqp_encode_bytes`, which used the identical pattern.

## Tests

Adds `tests/test_decode_bytes.c` (wired into CTest as `decode_bytes`) covering:
- valid in-bounds decodes (full buffer, partial-at-offset, zero length)
- plain out-of-bounds lengths/offsets
- the advisory's overflow/wraparound cases (e.g. `offset + len == 0 (mod 2^N)`, `len == SIZE_MAX`, `len == 0xFFFFFFF5`)

These cases pass under the fix and would have been accepted (failed) under the old logic, so the test guards against regression. Full suite (`ctest`) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)