### PR TITLE
Require POPT v1.14 or newer when building tools

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -167,7 +167,7 @@ if(BUILD_EXAMPLES)
 endif()
 
 if(BUILD_TOOLS)
-  find_package(POPT REQUIRED)
+  find_package(POPT 1.14 REQUIRED)
   if(BUILD_TOOLS_DOCS)
     find_package(XMLTO REQUIRED)
   endif()

--- a/cmake/FindPOPT.cmake
+++ b/cmake/FindPOPT.cmake
@@ -4,6 +4,12 @@
 #  POPT_FOUND - System has popt
 #  POPT_INCLUDE_DIR - The popt include directory
 #  POPT_LIBRARY - The libraries needed to use popt
+#  POPT_VERSION - The version of popt that was found
+#
+# This module also supports version requirements, e.g.
+# find_package(POPT 1.14 REQUIRED). popt does not expose its release
+# version in popt.h, so the version is obtained from pkg-config. A version
+# requirement therefore needs pkg-config and the popt.pc file to be available.
 
 # use pkg-config to get the directories and then use these values
 # in the FIND_PATH() and FIND_LIBRARY() calls


### PR DESCRIPTION
## Summary

The tools build depends on the popt options-processing library, but the CMake configuration previously accepted any version of popt. This change validates that **popt v1.14 or newer** is available.

Note that the library has always needed popt v1.14 or newer, this just adds this validation at build time with a more informative message when this requirement isn't met.

## Changes

- `CMakeLists.txt`: pass a minimum version to `find_package(POPT 1.14 REQUIRED)` so configuration fails early with a clear message when an older popt is present.
- `cmake/FindPOPT.cmake`: document the new `POPT_VERSION` output variable and note that version validation relies on pkg-config / `popt.pc` (popt does not expose its release version in `popt.h`). The module already wires the pkg-config version into `VERSION_VAR`, so no logic change was needed there.

## Verification

Configured locally with popt 1.19 installed:

```
-- Found POPT: /usr/include (found suitable version "1.19", minimum required is "1.14")
```

Confirmed the check also rejects unsuitable versions (tested by requesting an artificially high `99.0`):

```
Could NOT find POPT: Found unsuitable version "1.19", but required is at least "99.0"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KTnJajxhzDqAyratZ5rntE)_

Fixes #503 