### PR TITLE
Fix ioctlsocket type mismatch on Windows

### DIFF
--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -291,6 +291,7 @@ int amqp_open_socket_noblock(char const *hostname, int portnumber,
 #ifdef _WIN32
 static int connect_socket(struct addrinfo *addr, amqp_time_t deadline) {
   int one = 1;
+  u_long nonblocking = 1;
   SOCKET sockfd;
   int last_error;
 
@@ -305,7 +306,7 @@ static int connect_socket(struct addrinfo *addr, amqp_time_t deadline) {
   }
 
   /* Set the socket to be non-blocking */
-  if (SOCKET_ERROR == ioctlsocket(sockfd, FIONBIO, &one)) {
+  if (SOCKET_ERROR == ioctlsocket(sockfd, FIONBIO, &nonblocking)) {
     last_error = AMQP_STATUS_SOCKET_ERROR;
     goto err;
   }


### PR DESCRIPTION
## Summary

- `ioctlsocket()` on Windows requires `u_long *` as its third argument (per `winsock2.h`)
- The existing code passed `&one` where `one` is `int`, causing a compiler error with strict type-checking compilers (e.g. mingw with `-Wincompatible-pointer-types` treated as error)
- Introduce a separate `u_long nonblocking = 1;` variable used only for the `ioctlsocket` call; the existing `int one` is kept for the `setsockopt` calls which correctly take `int`

This fix is confined to the `#ifdef _WIN32` block, so Linux and macOS are unaffected.

Fixes #857

## Test plan

- [ ] Build on Windows (MSVC or MinGW) — compilation of `amqp_socket.c` should succeed without type-mismatch warnings/errors
- [ ] Build on Linux/macOS — no change in behavior, existing build passes
- [ ] Run existing integration tests to confirm socket non-blocking behavior is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Af9HDnUd5RwqhNzuP9jqkM)_