### PR TITLE
Fix amqp_socket.c compilation error on Windows (issue #857)

### DIFF
--- a/librabbitmq/amqp_socket.c
+++ b/librabbitmq/amqp_socket.c
@@ -290,7 +290,7 @@ int amqp_open_socket_noblock(char const *hostname, int portnumber,
 
 #ifdef _WIN32
 static int connect_socket(struct addrinfo *addr, amqp_time_t deadline) {
-  int one = 1;
+  u_long one = 1;
   SOCKET sockfd;
   int last_error;
 


### PR DESCRIPTION
The change updates the type of a variable used in a Windows-specific call to `ioctlsocket` from `int` to `u_long`. This ensures compatibility with the Windows Sockets API (Winsock) and resolves a compilation error reported in issue #857. The change is confined to a `#ifdef _WIN32` block and does not affect other platforms.

---
*PR created automatically by Jules for task [7927374557811745639](https://jules.google.com/task/7927374557811745639) started by @alanxz*