### PR TITLE
Fix heap buffer overflow in amqp_frame_to_bytes for oversized body frames

### DIFF
--- a/librabbitmq/amqp_connection.c
+++ b/librabbitmq/amqp_connection.c
@@ -464,6 +464,14 @@ static int amqp_frame_to_bytes(const amqp_frame_t *frame, amqp_bytes_t buffer,
     case AMQP_FRAME_BODY: {
       const amqp_bytes_t *body = &frame->payload.body_fragment;
 
+      /* Ensure the body fragment fits within the outbound buffer, leaving
+       * room for the frame header and footer. Without this check an
+       * oversized body fragment would overflow the heap-allocated buffer. */
+      if (buffer.len < HEADER_SIZE + FOOTER_SIZE ||
+          body->len > buffer.len - (HEADER_SIZE + FOOTER_SIZE)) {
+        return AMQP_STATUS_BAD_AMQP_DATA;
+      }
+
       memcpy(amqp_offset(out_frame, HEADER_SIZE), body->bytes, body->len);
 
       out_frame_len = body->len;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -44,3 +44,7 @@ add_test(sasl_mechanism test_sasl_mechanism)
 add_executable(test_merge_capabilities test_merge_capabilities.c)
 target_link_libraries(test_merge_capabilities rabbitmq-static)
 add_test(merge_capabilities test_merge_capabilities)
+
+add_executable(test_send_frame test_send_frame.c)
+target_link_libraries(test_send_frame rabbitmq-static)
+add_test(send_frame test_send_frame)

--- a/tests/test_send_frame.c
+++ b/tests/test_send_frame.c
@@ -1,0 +1,57 @@
+// Copyright 2007 - 2021, Alan Antonuk and the rabbitmq-c contributors.
+// SPDX-License-Identifier: mit
+
+#include "amqp_private.h"
+#include <rabbitmq-c/amqp.h>
+#include <rabbitmq-c/framing.h>
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* Regression test for GHSA-hfjv-vcp3-39wh: passing an oversized
+ * AMQP_FRAME_BODY to amqp_send_frame() must not overflow the outbound
+ * buffer. It should be rejected with AMQP_STATUS_BAD_AMQP_DATA. */
+static void test_oversized_body_frame_rejected(void) {
+  amqp_connection_state_t state = amqp_new_connection();
+  amqp_frame_t frame;
+  size_t body_len;
+  char *body;
+  int res;
+
+  if (state == NULL) {
+    fprintf(stderr, "amqp_new_connection failed\n");
+    abort();
+  }
+
+  /* The default outbound buffer is AMQP_DEFAULT_FRAME_SIZE bytes; use a
+   * body fragment that is larger than that buffer can hold. */
+  body_len = state->outbound_buffer.len + 1024;
+  body = malloc(body_len);
+  if (body == NULL) {
+    fprintf(stderr, "malloc failed\n");
+    abort();
+  }
+  memset(body, 'A', body_len);
+
+  memset(&frame, 0, sizeof(frame));
+  frame.frame_type = AMQP_FRAME_BODY;
+  frame.channel = 1;
+  frame.payload.body_fragment.bytes = body;
+  frame.payload.body_fragment.len = body_len;
+
+  res = amqp_send_frame(state, &frame);
+  if (res != AMQP_STATUS_BAD_AMQP_DATA) {
+    fprintf(stderr, "expected AMQP_STATUS_BAD_AMQP_DATA (%d), got %d\n",
+            AMQP_STATUS_BAD_AMQP_DATA, res);
+    abort();
+  }
+
+  free(body);
+  amqp_destroy_connection(state);
+}
+
+int main(void) {
+  test_oversized_body_frame_rejected();
+  return 0;
+}


### PR DESCRIPTION
## Summary

Fixes the heap buffer overflow reported in [GHSA-hfjv-vcp3-39wh](https://github.com/alanxz/rabbitmq-c/security/advisories/GHSA-hfjv-vcp3-39wh).

`amqp_send_frame()` → `amqp_send_frame_inner()` → `amqp_frame_to_bytes()` serialized an `AMQP_FRAME_BODY` by `memcpy`-ing `frame.payload.body_fragment.len` bytes into the connection's outbound buffer **without validating that the body fragment fits**. An application passing an oversized body frame to the public `amqp_send_frame()` API triggered a heap out-of-bounds write (process crash / memory corruption), before any network I/O.

The outbound buffer is sized to `frame_max` (default 65536 bytes). The other frame types (`METHOD`, `HEADER`) already bound their encoders to `buffer.len - HEADER_SIZE - … - FOOTER_SIZE`; only the `BODY` case trusted the caller-supplied length directly.

## Fix

In the `AMQP_FRAME_BODY` case of `amqp_frame_to_bytes()`, validate that the body fragment fits within the usable payload space (`buffer.len - HEADER_SIZE - FOOTER_SIZE`). If it does not, return `AMQP_STATUS_BAD_AMQP_DATA` instead of overflowing the buffer. The check is written to avoid `size_t` underflow when the buffer is unexpectedly small. This matches the bound the higher-level publish path (`amqp_api.c`) already uses when splitting bodies into frames.

## Testing

- Added `tests/test_send_frame.c` — a regression test that constructs an oversized `AMQP_FRAME_BODY` and asserts `amqp_send_frame()` returns `AMQP_STATUS_BAD_AMQP_DATA`.
- Built with `-fsanitize=address`; the new test passes with no overflow (previously ASan reported a heap-buffer-overflow at `amqp_connection.c:467`).
- Full `ctest` suite passes (7/7).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LSk2fbTxxZS9STJX6Y9Uge

---
_Generated by [Claude Code](https://claude.ai/code/session_01LSk2fbTxxZS9STJX6Y9Uge)_