### PR TITLE
tools: make rabbitmq-tools use default cert paths (fixes #868)

### DIFF
--- a/tools/common.c
+++ b/tools/common.c
@@ -164,8 +164,8 @@ struct poptOption connect_options[] = {
      "path to the client private key file", "key.pem"},
     {"cert", 0, POPT_ARG_STRING, &amqp_cert, 0,
      "path to the client certificate file", "cert.pem"},
-    {"no-default-cert-paths", 0, POPT_ARG_NONE, &amqp_no_default_cert_paths,
-     0, "do not use default certificate paths", NULL},
+    {"no-default-cert-paths", 0, POPT_ARG_NONE, &amqp_no_default_cert_paths, 0,
+     "do not use default certificate paths", NULL},
 #endif /* WITH_SSL */
     {NULL, '\0', 0, NULL, 0, NULL, NULL}};
 

--- a/tools/common.c
+++ b/tools/common.c
@@ -136,6 +136,7 @@ static int amqp_ssl = 0;
 static char *amqp_cacert = "/etc/ssl/certs/cacert.pem";
 static char *amqp_key = NULL;
 static char *amqp_cert = NULL;
+static int amqp_no_default_cert_paths = 0;
 #endif /* WITH_SSL */
 
 const char *connect_options_title = "Connection options";
@@ -163,10 +164,12 @@ struct poptOption connect_options[] = {
      "path to the client private key file", "key.pem"},
     {"cert", 0, POPT_ARG_STRING, &amqp_cert, 0,
      "path to the client certificate file", "cert.pem"},
+    {"no-default-cert-paths", 0, POPT_ARG_NONE, &amqp_no_default_cert_paths,
+     0, "do not use default certificate paths", NULL},
 #endif /* WITH_SSL */
     {NULL, '\0', 0, NULL, 0, NULL, NULL}};
 
-void read_authfile(const char *path) {
+static void read_authfile(const char *path) {
   size_t n;
   FILE *fp = NULL;
   char token[MAXAUTHTOKENLEN];
@@ -360,6 +363,9 @@ amqp_connection_state_t make_connection(void) {
     }
     if (amqp_key) {
       amqp_ssl_socket_set_key(socket, amqp_cert, amqp_key);
+    }
+    if (!amqp_no_default_cert_paths) {
+      amqp_ssl_socket_enable_default_verify_paths(socket);
     }
 #else
     die("librabbitmq was not built with SSL/TLS support");


### PR DESCRIPTION
Implements the feature requested in #868, based on PR #869 by @the-mech with fixes applied.

## Changes

- Add `--no-default-cert-paths` CLI flag to SSL tool options
- When SSL is active, call `amqp_ssl_socket_enable_default_verify_paths()` by default (opt-out via `--no-default-cert-paths`)
- Make `read_authfile()` `static` (it has no external callers)

## Fixes #868 vs original PR #869

- Added missing trailing comma after the new popt option entry (syntax error in original)
- Fixed indentation to match clang-format style used in the rest of the file

## Attribution

Co-authored-by: the-mech <10233279+the-mech@users.noreply.github.com>

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ci1wEhJSpT6v1HZnx8ajmM)_