### PR TITLE
docs: document encoded buffer lifetime requirement in amqp_decode_table

### DIFF
--- a/include/rabbitmq-c/amqp.h
+++ b/include/rabbitmq-c/amqp.h
@@ -2016,7 +2016,15 @@ const char *AMQP_CALL amqp_error_string2(int err);
  * This is an internal function and is not typically used by
  * client applications
  *
- * \param [in] encoded the buffer containing the serialized data
+ * \warning The decoded table entries contain direct references (pointers) into
+ *  the \p encoded buffer rather than independent copies. The \p encoded buffer
+ *  **must** remain valid and unmodified for as long as the decoded table (or
+ *  any data derived from it) is in use. Freeing or modifying \p encoded while
+ *  the table is still live will result in use-after-free. Use
+ *  amqp_table_clone() if you need a fully independent copy of the table.
+ *
+ * \param [in] encoded the buffer containing the serialized data. Must outlive
+ *             the decoded \p output table.
  * \param [in] pool memory pool used to allocate the table entries from
  * \param [in] output the amqp_table_t structure to fill in. Any existing
  *             entries will be erased


### PR DESCRIPTION
## Summary

Addresses a security advisory reporting a potential use-after-free (UAF) with `amqp_decode_table`.

The root behavior is intentional by design: decoded table entries hold direct pointers into the `encoded` byte buffer rather than independent pool-allocated copies. This is an implicit lifetime contract that was not previously documented.

- Adds a `\warning` block to the `amqp_decode_table` Doxygen comment explicitly stating that `encoded` must outlive the decoded table (and any data derived from it, e.g. via `amqp_table_clone()`).
- Updates the `\param encoded` description to reinforce the lifetime requirement.
- Directs callers to `amqp_table_clone()` when a fully independent copy is needed.

No behavioral changes — documentation only.

---
_Generated by [Claude Code](https://claude.ai/code/session_01M4wRYY2fXRzxeXqyRZJ7eC)_